### PR TITLE
feat: event stream consumption methods

### DIFF
--- a/event-stream-consumption-spec.md
+++ b/event-stream-consumption-spec.md
@@ -1,0 +1,200 @@
+# Feature: Event Stream Consumption
+
+## Overview
+
+**User Story**: As an orchestrator component (supervisor, DAG engine, UI), I want to read and subscribe to the event stream so that I can react to agent state changes and task lifecycle events in real time.
+
+**Problem**: `StateStore` can publish events via `PublishEvent` (XADD) but has no read-side methods. F2 (supervisor), F3 (DAG engine), and F4 (UI) are all blocked on having a consumption path for the event stream.
+
+**Out of Scope**: Dead-letter queue handling, stream trimming/retention policies, consumer-specific filtering logic (consumers filter in application code).
+
+---
+
+## Success Condition
+
+> This feature is complete when any StateStore consumer can perform one-shot reads (XREAD), subscribe via consumer groups (XREADGROUP), acknowledge processed events (XACK), create consumer groups idempotently, and all operations pass conformance tests against both the Redis and mock implementations -- including a Redis integration test demonstrating two competing consumers processing events concurrently with distinct delivery.
+
+---
+
+## Open Questions
+
+| # | Question | Raised By | Resolved |
+|:--|:---------|:----------|:---------|
+| 1 | Should consumer groups be auto-created on first SubscribeEvents call, or require explicit CreateConsumerGroup? | Spec author | [x] Explicit — CreateConsumerGroup is a separate interface method |
+| 2 | Does the Event struct need a stream ID field for ack? | Spec author | [x] Yes — new `StreamEvent` wrapper: `{ ID string; Event Event }` |
+
+---
+
+## Scope
+
+### Must-Have
+- **M1 — ReadEvents (one-shot XREAD)**: Given published events, `ReadEvents(ctx, lastID, count)` returns up to `count` `StreamEvent`s after `lastID`; returns empty slice when no new events exist
+- **M2 — CreateConsumerGroup**: `CreateConsumerGroup(ctx, group, startID)` creates a Redis consumer group on the event stream; idempotent (no error if group already exists)
+- **M3 — SubscribeEvents (XREADGROUP)**: `SubscribeEvents(ctx, group, consumer, count, block)` returns events assigned to that consumer; competing consumers each get distinct events
+- **M4 — AckEvent**: `AckEvent(ctx, group, ids...)` acknowledges processed events; acked events are not re-delivered
+- **M5 — StreamEvent wrapper**: A `StreamEvent` struct wrapping `Event` + the Redis-assigned stream entry ID; all read methods return `[]StreamEvent`
+- **M6 — Mock implementation**: MockStore implements all new methods with in-memory consumer group semantics (round-robin delivery, pending event tracking)
+- **M7 — Conformance tests**: Shared test suite covers all must-haves; passes on both Mock and Redis implementations
+- **M8 — Integration test**: Redis integration test demonstrating two competing consumers processing events concurrently, each receiving distinct events
+
+### Should-Have
+- **Pending event list (XPENDING)**: Inspect unacked messages per consumer for health monitoring
+
+### Nice-to-Have
+- None
+
+---
+
+## Technical Plan
+
+**Affected Components**:
+- `internal/state/store.go` — `StreamEvent` type + 4 new methods on `StateStore` interface
+- `internal/state/redis.go` — Redis implementations (XREAD, XGROUP CREATE, XREADGROUP, XACK)
+- `internal/state/mock.go` — in-memory implementations with simulated consumer groups
+- `internal/state/store_test.go` — conformance tests for new methods
+- `internal/state/redis_test.go` — competing-consumer integration test
+- `internal/state/errors.go` — potential new sentinel errors
+
+**Data Model Changes**:
+- No new Redis keys — uses existing `{prefix}events` stream
+- Consumer groups are created on the existing stream via XGROUP CREATE
+
+**API Contracts** (Go interface additions):
+
+```go
+// StreamEvent wraps an Event with its Redis-assigned stream entry ID.
+type StreamEvent struct {
+    ID    string // Redis stream entry ID (e.g., "1234567890-0")
+    Event Event
+}
+
+// New methods on StateStore:
+ReadEvents(ctx context.Context, lastID string, count int64) ([]StreamEvent, error)
+CreateConsumerGroup(ctx context.Context, group string, startID string) error
+SubscribeEvents(ctx context.Context, group, consumer string, count int64, block time.Duration) ([]StreamEvent, error)
+AckEvent(ctx context.Context, group string, ids ...string) error
+```
+
+**Design decisions**:
+- Stream key is hidden — callers don't pass it (single event stream, matches `PublishEvent` pattern)
+- `SubscribeEvents` is synchronous (returns `[]StreamEvent`) — callers wrap in goroutine loops; simpler to test than channel-based
+- `CreateConsumerGroup` uses `MKSTREAM` flag to avoid errors if the stream doesn't exist yet
+- Mock consumer groups: track assigned-but-unacked events per consumer, round-robin delivery across consumers in the same group
+
+**Dependencies**: None new — `go-redis/v9` already supports XREAD, XREADGROUP, XACK, XGROUP
+
+**Risks**:
+| Risk | Likelihood | Mitigation |
+|:-----|:-----------|:-----------|
+| Mock consumer group semantics diverge from Redis behavior | Medium | Conformance tests run against both impls; keep mock simple (round-robin, no redelivery timeout) |
+| XREADGROUP blocking in tests causes flaky timeouts | Medium | Use short block durations (10-50ms) in tests; always publish before subscribing in happy path |
+| Stream ID format differences between Redis and mock | Low | Mock generates monotonic `"mock-{n}"` IDs; tests compare by count/content, not by ID format |
+
+---
+
+## Acceptance Scenarios
+
+```gherkin
+Feature: Event Stream Consumption
+  As an orchestrator component
+  I want to read and subscribe to the event stream
+  So that I can react to agent state changes and task lifecycle events
+
+  Background:
+    Given a StateStore with no prior events
+
+  Rule: One-shot reads return events after a cursor
+
+    Scenario: ReadEvents returns published events
+      Given 3 events have been published
+      When I call ReadEvents with lastID "0" and count 10
+      Then I receive 3 StreamEvents with matching Event payloads
+      And each StreamEvent has a non-empty ID
+
+    Scenario: ReadEvents with cursor returns only newer events
+      Given 3 events have been published
+      And I record the ID of the 2nd event
+      When I call ReadEvents with that ID and count 10
+      Then I receive 1 StreamEvent (the 3rd event only)
+
+    Scenario: ReadEvents on empty stream returns empty slice
+      When I call ReadEvents with lastID "0" and count 10
+      Then I receive an empty slice and no error
+
+  Rule: Consumer groups enable competing consumption
+
+    Scenario: CreateConsumerGroup is idempotent
+      When I call CreateConsumerGroup with group "workers" and startID "0"
+      And I call CreateConsumerGroup with group "workers" and startID "0" again
+      Then both calls succeed without error
+
+    Scenario: SubscribeEvents delivers events to a consumer
+      Given a consumer group "workers" starting from "0"
+      And 3 events have been published
+      When consumer "w1" calls SubscribeEvents with count 10
+      Then consumer "w1" receives 3 StreamEvents
+
+    Scenario: Competing consumers receive distinct events
+      Given a consumer group "workers" starting from "0"
+      And 6 events have been published
+      When consumer "w1" and "w2" each call SubscribeEvents with count 10
+      Then the union of their results is all 6 events
+      And no event appears in both results
+
+  Rule: Acknowledgement prevents redelivery
+
+    Scenario: Acked events are not re-delivered
+      Given a consumer group "workers" starting from "0"
+      And 2 events have been published
+      And consumer "w1" receives both events via SubscribeEvents
+      When consumer "w1" acks both event IDs
+      And consumer "w1" calls SubscribeEvents again
+      Then consumer "w1" receives an empty slice
+
+    # Future / Out of Scope — requires XCLAIM/XAUTOCLAIM interface additions
+    # Scenario: Unacked events can be reclaimed
+    #   Given a consumer group "workers" starting from "0"
+    #   And 1 event has been published
+    #   And consumer "w1" receives the event but does not ack
+    #   When consumer "w2" reads with startID "0" (claiming pending)
+    #   Then consumer "w2" can receive the unacked event
+```
+
+---
+
+## Task Breakdown
+
+| ID | Task | Priority | Dependencies | Status |
+|:---|:-----|:---------|:-------------|:-------|
+| T1 | Add `StreamEvent` type and 4 new methods to `StateStore` interface in `store.go` | High | None | pending |
+| T2 | Implement `ReadEvents` in `redis.go` (XREAD) and `mock.go` | High | T1 | pending |
+| T3 | Implement `CreateConsumerGroup` in `redis.go` (XGROUP CREATE) and `mock.go` | High | T1 | pending |
+| T4 | Implement `SubscribeEvents` in `redis.go` (XREADGROUP) and `mock.go` | High | T1, T3 | pending |
+| T5 | Implement `AckEvent` in `redis.go` (XACK) and `mock.go` | High | T1, T4 | pending |
+| T6 | Add conformance tests to `store_test.go` for all new methods | High | T2-T5 | pending |
+| T7 | Add competing-consumer integration test in `redis_test.go` | High | T6 | pending |
+| T8 | Add new sentinel errors to `errors.go` if needed | Med | T1 | pending |
+
+Notes: T2 and T3 can be parallelized. T4 depends on T3 (needs consumer groups). T5 depends on T4 (needs stream IDs from subscribe).
+
+---
+
+## Exit Criteria
+
+- [ ] All Must-Have acceptance scenarios pass in conformance tests (Mock + Redis)
+- [ ] Competing-consumer integration test passes against real Redis
+- [ ] No regressions on existing conformance tests (`RunStateStoreConformance`)
+- [ ] `StateStore` interface additions compile with existing implementations
+- [ ] API contracts match implementation signatures
+
+---
+
+## References
+
+- Issue: [#17 — Event Stream Consumption Methods for StateStore](https://github.com/Kiriketsuki/agenKic-orKistrator/issues/17)
+- PR: [#23 — feat: event stream consumption methods](https://github.com/Kiriketsuki/agenKic-orKistrator/pull/23)
+- Parent spec: `specs/foundation-scaffold-proto-redis-agent-spec.md`
+- Parent spec: `specs/go-orchestrator-core-spec.md`
+
+---
+*Authored by: Clault KiperS 4.6*

--- a/internal/state/mock.go
+++ b/internal/state/mock.go
@@ -279,6 +279,12 @@ func (m *MockStore) PublishEvent(ctx context.Context, event Event) error {
 	return nil
 }
 
+// ReadEvents returns up to count StreamEvents published after lastID.
+// Note: unlike Redis XREAD which treats lastID as a lexicographic lower bound,
+// the mock requires lastID to exactly match an existing entry's ID. Cursor IDs
+// from a different mock instance or in Redis format (e.g. "1711234567890-0")
+// will return empty. This is acceptable for unit tests where cursors always
+// come from prior ReadEvents/SubscribeEvents calls in the same test run.
 func (m *MockStore) ReadEvents(ctx context.Context, lastID string, count int64) ([]StreamEvent, error) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
@@ -330,20 +336,7 @@ func (m *MockStore) CreateConsumerGroup(ctx context.Context, group string, start
 	return nil
 }
 
-func (m *MockStore) SubscribeEvents(ctx context.Context, group, consumer string, count int64, block time.Duration) ([]StreamEvent, error) {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-
-	g, ok := m.groups[group]
-	if !ok {
-		return nil, fmt.Errorf("SubscribeEvents: group %q not found", group)
-	}
-	c, ok := g.consumers[consumer]
-	if !ok {
-		c = &mockConsumer{pending: make(map[string]bool)}
-		g.consumers[consumer] = c
-	}
-
+func (m *MockStore) subscribeEventsLocked(g *mockGroup, c *mockConsumer, count int64) []StreamEvent {
 	result := make([]StreamEvent, 0)
 	delivered := 0
 	for g.lastDelivered < len(m.streamEvents) && int64(delivered) < count {
@@ -353,7 +346,51 @@ func (m *MockStore) SubscribeEvents(ctx context.Context, group, consumer string,
 		g.lastDelivered++
 		delivered++
 	}
-	return result, nil
+	return result
+}
+
+func (m *MockStore) SubscribeEvents(ctx context.Context, group, consumer string, count int64, block time.Duration) ([]StreamEvent, error) {
+	m.mu.Lock()
+
+	g, ok := m.groups[group]
+	if !ok {
+		m.mu.Unlock()
+		return nil, fmt.Errorf("SubscribeEvents: group %q not found", group)
+	}
+	c, ok := g.consumers[consumer]
+	if !ok {
+		c = &mockConsumer{pending: make(map[string]bool)}
+		g.consumers[consumer] = c
+	}
+
+	result := m.subscribeEventsLocked(g, c, count)
+	if len(result) > 0 || block <= 0 {
+		m.mu.Unlock()
+		return result, nil
+	}
+	m.mu.Unlock()
+
+	// Honor the block parameter: wait up to block duration for new events,
+	// matching Redis XREADGROUP behavior. Poll in short intervals so we
+	// respond promptly to context cancellation and new events.
+	deadline := time.After(block)
+	ticker := time.NewTicker(5 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return []StreamEvent{}, ctx.Err()
+		case <-deadline:
+			return []StreamEvent{}, nil
+		case <-ticker.C:
+			m.mu.Lock()
+			result = m.subscribeEventsLocked(g, c, count)
+			m.mu.Unlock()
+			if len(result) > 0 {
+				return result, nil
+			}
+		}
+	}
 }
 
 func (m *MockStore) AckEvent(ctx context.Context, group string, ids ...string) error {

--- a/internal/state/mock.go
+++ b/internal/state/mock.go
@@ -2,6 +2,7 @@ package state
 
 import (
 	"context"
+	"fmt"
 	"sort"
 	"sync"
 	"time"
@@ -13,6 +14,9 @@ type MockStore struct {
 	mu                    sync.RWMutex
 	agents                map[string]*agentRecord // agentID -> record
 	events                []Event
+	streamEvents          []mockStreamEvent
+	streamSeq             int64
+	groups                map[string]*mockGroup
 	queue                 []queueItem // sorted by priority ascending
 	pingErr               error
 	getAllAgentStatesErr  error
@@ -36,10 +40,26 @@ type queueItem struct {
 	priority float64
 }
 
+type mockStreamEvent struct {
+	ID    string
+	Event Event
+}
+
+type mockGroup struct {
+	startIdx      int // index into streamEvents where this group starts consuming
+	lastDelivered int // index of last delivered event (for round-robin)
+	consumers     map[string]*mockConsumer
+}
+
+type mockConsumer struct {
+	pending map[string]bool // set of unacked stream event IDs
+}
+
 // NewMockStore returns a ready-to-use in-memory store.
 func NewMockStore() *MockStore {
 	return &MockStore{
 		agents:                make(map[string]*agentRecord),
+		groups:                make(map[string]*mockGroup),
 		getAgentFieldsByAgent: make(map[string]error),
 		setAgentFieldsByAgent: make(map[string]error),
 	}
@@ -253,6 +273,102 @@ func (m *MockStore) PublishEvent(ctx context.Context, event Event) error {
 		event.Timestamp = time.Now().UnixMilli()
 	}
 	m.events = append(m.events, event)
+	m.streamSeq++
+	id := fmt.Sprintf("mock-%d", m.streamSeq)
+	m.streamEvents = append(m.streamEvents, mockStreamEvent{ID: id, Event: event})
+	return nil
+}
+
+func (m *MockStore) ReadEvents(ctx context.Context, lastID string, count int64) ([]StreamEvent, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	result := make([]StreamEvent, 0)
+	if lastID == "0" || lastID == "0-0" {
+		for i, se := range m.streamEvents {
+			if int64(i) >= count {
+				break
+			}
+			result = append(result, StreamEvent{ID: se.ID, Event: se.Event})
+		}
+		return result, nil
+	}
+
+	// Find the entry matching lastID and return everything after it.
+	startIdx := -1
+	for i, se := range m.streamEvents {
+		if se.ID == lastID {
+			startIdx = i + 1
+			break
+		}
+	}
+	if startIdx < 0 {
+		return result, nil
+	}
+	for i := startIdx; i < len(m.streamEvents) && int64(i-startIdx) < count; i++ {
+		result = append(result, StreamEvent{ID: m.streamEvents[i].ID, Event: m.streamEvents[i].Event})
+	}
+	return result, nil
+}
+
+func (m *MockStore) CreateConsumerGroup(ctx context.Context, group string, startID string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if _, ok := m.groups[group]; ok {
+		return nil
+	}
+	startIdx := 0
+	if startID == "$" {
+		startIdx = len(m.streamEvents)
+	}
+	m.groups[group] = &mockGroup{
+		startIdx:      startIdx,
+		lastDelivered: startIdx,
+		consumers:     make(map[string]*mockConsumer),
+	}
+	return nil
+}
+
+func (m *MockStore) SubscribeEvents(ctx context.Context, group, consumer string, count int64, block time.Duration) ([]StreamEvent, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	g, ok := m.groups[group]
+	if !ok {
+		return nil, fmt.Errorf("SubscribeEvents: group %q not found", group)
+	}
+	c, ok := g.consumers[consumer]
+	if !ok {
+		c = &mockConsumer{pending: make(map[string]bool)}
+		g.consumers[consumer] = c
+	}
+
+	result := make([]StreamEvent, 0)
+	delivered := 0
+	for g.lastDelivered < len(m.streamEvents) && int64(delivered) < count {
+		se := m.streamEvents[g.lastDelivered]
+		result = append(result, StreamEvent{ID: se.ID, Event: se.Event})
+		c.pending[se.ID] = true
+		g.lastDelivered++
+		delivered++
+	}
+	return result, nil
+}
+
+func (m *MockStore) AckEvent(ctx context.Context, group string, ids ...string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	g, ok := m.groups[group]
+	if !ok {
+		return fmt.Errorf("AckEvent: group %q not found", group)
+	}
+	for _, c := range g.consumers {
+		for _, id := range ids {
+			delete(c.pending, id)
+		}
+	}
 	return nil
 }
 

--- a/internal/state/redis.go
+++ b/internal/state/redis.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/redis/go-redis/v9"
@@ -321,6 +322,88 @@ func (r *RedisStore) PublishEvent(ctx context.Context, event Event) error {
 	}
 	if err := r.client.XAdd(ctx, args).Err(); err != nil {
 		return fmt.Errorf("PublishEvent: %w", err)
+	}
+	return nil
+}
+
+func parseXMessages(msgs []redis.XMessage) []StreamEvent {
+	events := make([]StreamEvent, 0, len(msgs))
+	for _, msg := range msgs {
+		var ts int64
+		if v, ok := msg.Values["timestamp"].(string); ok && v != "" {
+			ts, _ = strconv.ParseInt(v, 10, 64)
+		}
+		events = append(events, StreamEvent{
+			ID: msg.ID,
+			Event: Event{
+				Type:      fmt.Sprintf("%v", msg.Values["type"]),
+				AgentID:   fmt.Sprintf("%v", msg.Values["agent_id"]),
+				TaskID:    fmt.Sprintf("%v", msg.Values["task_id"]),
+				Timestamp: ts,
+				Payload:   fmt.Sprintf("%v", msg.Values["payload"]),
+			},
+		})
+	}
+	return events
+}
+
+func (r *RedisStore) ReadEvents(ctx context.Context, lastID string, count int64) ([]StreamEvent, error) {
+	results, err := r.client.XRead(ctx, &redis.XReadArgs{
+		Streams: []string{r.key(streamKey), lastID},
+		Count:   count,
+		Block:   -1, // negative = non-blocking (omits BLOCK arg); 0 would block forever
+	}).Result()
+	if err == redis.Nil {
+		return []StreamEvent{}, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("ReadEvents: %w", err)
+	}
+	if len(results) == 0 {
+		return []StreamEvent{}, nil
+	}
+	return parseXMessages(results[0].Messages), nil
+}
+
+func (r *RedisStore) CreateConsumerGroup(ctx context.Context, group string, startID string) error {
+	err := r.client.XGroupCreateMkStream(ctx, r.key(streamKey), group, startID).Err()
+	if err != nil && strings.Contains(err.Error(), "BUSYGROUP") {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("CreateConsumerGroup: %w", err)
+	}
+	return nil
+}
+
+func (r *RedisStore) SubscribeEvents(ctx context.Context, group, consumer string, count int64, block time.Duration) ([]StreamEvent, error) {
+	// go-redis: Block 0 = BLOCK 0 (block forever). Use -1 to omit the
+	// BLOCK arg entirely, making the call non-blocking when block <= 0.
+	if block <= 0 {
+		block = -1
+	}
+	results, err := r.client.XReadGroup(ctx, &redis.XReadGroupArgs{
+		Group:    group,
+		Consumer: consumer,
+		Streams:  []string{r.key(streamKey), ">"},
+		Count:    count,
+		Block:    block,
+	}).Result()
+	if err == redis.Nil {
+		return []StreamEvent{}, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("SubscribeEvents: %w", err)
+	}
+	if len(results) == 0 {
+		return []StreamEvent{}, nil
+	}
+	return parseXMessages(results[0].Messages), nil
+}
+
+func (r *RedisStore) AckEvent(ctx context.Context, group string, ids ...string) error {
+	if err := r.client.XAck(ctx, r.key(streamKey), group, ids...).Err(); err != nil {
+		return fmt.Errorf("AckEvent: %w", err)
 	}
 	return nil
 }

--- a/internal/state/redis_test.go
+++ b/internal/state/redis_test.go
@@ -5,7 +5,9 @@ package state_test
 import (
 	"fmt"
 	"os"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/Kiriketsuki/agenKic-orKistrator/internal/state"
 	"github.com/google/uuid"
@@ -27,4 +29,81 @@ func TestRedisStore_Conformance(t *testing.T) {
 	t.Cleanup(func() { store.Close() })
 
 	RunStateStoreConformance(t, store)
+}
+
+func TestRedisStore_CompetingConsumers(t *testing.T) {
+	redisURL := os.Getenv("REDIS_URL")
+	if redisURL == "" {
+		redisURL = "redis://localhost:6379"
+	}
+
+	prefix := fmt.Sprintf("test:%s:", uuid.New().String())
+	store, err := state.NewRedisStore(redisURL, state.WithKeyPrefix(prefix))
+	if err != nil {
+		t.Skipf("cannot connect to Redis at %s: %v", redisURL, err)
+	}
+	t.Cleanup(func() { store.Close() })
+
+	ctx := t.Context()
+
+	// Publish 10 events.
+	const total = 10
+	for i := 1; i <= total; i++ {
+		ev := state.Event{
+			Type:    "compete-type",
+			AgentID: fmt.Sprintf("cc-agent-%d", i),
+			TaskID:  fmt.Sprintf("cc-task-%d", i),
+		}
+		if err := store.PublishEvent(ctx, ev); err != nil {
+			t.Fatalf("PublishEvent %d: %v", i, err)
+		}
+	}
+
+	if err := store.CreateConsumerGroup(ctx, "competing-test", "0"); err != nil {
+		t.Fatalf("CreateConsumerGroup: %v", err)
+	}
+
+	// Two consumers collect events concurrently; each loops until a call
+	// returns empty (no new events available with a short block).
+	type result struct {
+		events []state.StreamEvent
+	}
+	results := make([]result, 2)
+	var wg sync.WaitGroup
+	for i := 0; i < 2; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			consumer := fmt.Sprintf("c%d", idx+1)
+			var collected []state.StreamEvent
+			for {
+				batch, err := store.SubscribeEvents(ctx, "competing-test", consumer, 10, 10*time.Millisecond)
+				if err != nil {
+					t.Errorf("SubscribeEvents %s: %v", consumer, err)
+					return
+				}
+				if len(batch) == 0 {
+					break
+				}
+				collected = append(collected, batch...)
+			}
+			results[idx].events = collected
+		}(i)
+	}
+	wg.Wait()
+
+	// Union all received IDs — expect exactly 10 with no duplicates.
+	seen := make(map[string]bool)
+	for _, r := range results {
+		for _, ev := range r.events {
+			if seen[ev.ID] {
+				t.Fatalf("duplicate event ID %q received by multiple consumers", ev.ID)
+			}
+			seen[ev.ID] = true
+		}
+	}
+	if len(seen) != total {
+		t.Fatalf("want %d distinct events across consumers, got %d (c1=%d, c2=%d)",
+			total, len(seen), len(results[0].events), len(results[1].events))
+	}
 }

--- a/internal/state/store.go
+++ b/internal/state/store.go
@@ -1,6 +1,9 @@
 package state
 
-import "context"
+import (
+	"context"
+	"time"
+)
 
 // AgentState* are the canonical lifecycle state strings stored in Redis.
 // Both the state package and any consumer that inspects state strings must use
@@ -19,6 +22,12 @@ type AgentFields struct {
 	CurrentTaskID       string
 	CurrentTaskPriority float64 // original priority for crash re-enqueue
 	RegisteredAt        int64   // unix millis
+}
+
+// StreamEvent wraps an Event with its Redis-assigned stream entry ID.
+type StreamEvent struct {
+	ID    string // Redis stream entry ID (e.g., "1234567890-0")
+	Event Event
 }
 
 // Event represents an entry published to the event stream.
@@ -77,6 +86,19 @@ type StateStore interface {
 
 	// ── Event stream ─────────────────────────────────────────────────────────
 	PublishEvent(ctx context.Context, event Event) error
+	// ReadEvents returns up to count StreamEvents published after lastID.
+	// Use "0" to read from the beginning. Returns an empty slice when no
+	// new events exist.
+	ReadEvents(ctx context.Context, lastID string, count int64) ([]StreamEvent, error)
+	// CreateConsumerGroup creates a consumer group on the event stream.
+	// Idempotent — returns nil if the group already exists.
+	CreateConsumerGroup(ctx context.Context, group string, startID string) error
+	// SubscribeEvents reads events via a consumer group (XREADGROUP).
+	// Returns events assigned to the named consumer; competing consumers
+	// in the same group each receive distinct events.
+	SubscribeEvents(ctx context.Context, group, consumer string, count int64, block time.Duration) ([]StreamEvent, error)
+	// AckEvent acknowledges processed events so they are not re-delivered.
+	AckEvent(ctx context.Context, group string, ids ...string) error
 
 	// ── Agent task binding ──────────────────────────────────────────────────
 	// ClearCurrentTask atomically zeroes CurrentTaskID and CurrentTaskPriority

--- a/internal/state/store_test.go
+++ b/internal/state/store_test.go
@@ -3,6 +3,7 @@ package state_test
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 	"time"
 
@@ -358,6 +359,220 @@ func RunStateStoreConformance(t *testing.T, store state.StateStore) {
 		got, _ := store.GetAgentState(ctx, agentID)
 		if got != "assigned" {
 			t.Fatalf("final state: want \"assigned\", got %q", got)
+		}
+	})
+
+	t.Run("ReadEvents returns published events", func(t *testing.T) {
+		evs := []state.Event{
+			{Type: "re-type-1", AgentID: "re-agent-1", TaskID: "re-task-1"},
+			{Type: "re-type-2", AgentID: "re-agent-2", TaskID: "re-task-2"},
+			{Type: "re-type-3", AgentID: "re-agent-3", TaskID: "re-task-3"},
+		}
+		for _, ev := range evs {
+			if err := store.PublishEvent(ctx, ev); err != nil {
+				t.Fatalf("PublishEvent: %v", err)
+			}
+		}
+		// Drain from beginning; prior sub-tests may have published events too.
+		all, err := store.ReadEvents(ctx, "0", 1000)
+		if err != nil {
+			t.Fatalf("ReadEvents: %v", err)
+		}
+		if len(all) < 3 {
+			t.Fatalf("want at least 3 events, got %d", len(all))
+		}
+		// Verify the last 3 match what we published.
+		got := all[len(all)-3:]
+		for i, ev := range evs {
+			if got[i].ID == "" {
+				t.Fatalf("event[%d] has empty ID", i)
+			}
+			if got[i].Event.Type != ev.Type {
+				t.Fatalf("event[%d].Type: want %q, got %q", i, ev.Type, got[i].Event.Type)
+			}
+			if got[i].Event.AgentID != ev.AgentID {
+				t.Fatalf("event[%d].AgentID: want %q, got %q", i, ev.AgentID, got[i].Event.AgentID)
+			}
+			if got[i].Event.TaskID != ev.TaskID {
+				t.Fatalf("event[%d].TaskID: want %q, got %q", i, ev.TaskID, got[i].Event.TaskID)
+			}
+		}
+	})
+
+	t.Run("ReadEvents with cursor returns only newer events", func(t *testing.T) {
+		evs := []state.Event{
+			{Type: "cur-type-1", AgentID: "cur-agent-1", TaskID: "cur-task-1"},
+			{Type: "cur-type-2", AgentID: "cur-agent-2", TaskID: "cur-task-2"},
+			{Type: "cur-type-3", AgentID: "cur-agent-3", TaskID: "cur-task-3"},
+		}
+		for _, ev := range evs {
+			if err := store.PublishEvent(ctx, ev); err != nil {
+				t.Fatalf("PublishEvent: %v", err)
+			}
+		}
+		// Read all to locate our 3 events (they are the last 3).
+		all, err := store.ReadEvents(ctx, "0", 1000)
+		if err != nil {
+			t.Fatalf("ReadEvents all: %v", err)
+		}
+		if len(all) < 3 {
+			t.Fatalf("want at least 3 events, got %d", len(all))
+		}
+		// The 2nd of our published events is at index len(all)-2.
+		secondID := all[len(all)-2].ID
+
+		// Read events after the 2nd one — should only get the 3rd.
+		after, err := store.ReadEvents(ctx, secondID, 10)
+		if err != nil {
+			t.Fatalf("ReadEvents with cursor: %v", err)
+		}
+		if len(after) != 1 {
+			t.Fatalf("want 1 event after cursor, got %d", len(after))
+		}
+		if after[0].Event.Type != "cur-type-3" {
+			t.Fatalf("want cur-type-3, got %q", after[0].Event.Type)
+		}
+	})
+
+	t.Run("ReadEvents on empty stream returns empty slice", func(t *testing.T) {
+		// The stream may have events from prior sub-tests. Advance to the
+		// current tail, then assert no further events exist.
+		all, err := store.ReadEvents(ctx, "0", 1000)
+		if err != nil {
+			t.Fatalf("ReadEvents drain: %v", err)
+		}
+		if len(all) == 0 {
+			// Stream was empty — already proven.
+			return
+		}
+		lastID := all[len(all)-1].ID
+		after, err := store.ReadEvents(ctx, lastID, 10)
+		if err != nil {
+			t.Fatalf("ReadEvents after tail: %v", err)
+		}
+		if len(after) != 0 {
+			t.Fatalf("want empty slice after tail, got %d events", len(after))
+		}
+	})
+
+	t.Run("CreateConsumerGroup is idempotent", func(t *testing.T) {
+		if err := store.CreateConsumerGroup(ctx, "cg-idem", "0"); err != nil {
+			t.Fatalf("CreateConsumerGroup (1st): %v", err)
+		}
+		if err := store.CreateConsumerGroup(ctx, "cg-idem", "0"); err != nil {
+			t.Fatalf("CreateConsumerGroup (2nd): %v", err)
+		}
+	})
+
+	t.Run("SubscribeEvents delivers events to a consumer", func(t *testing.T) {
+		// Create group at tail before publishing so we get exactly our 3 events.
+		if err := store.CreateConsumerGroup(ctx, "cg-sub", "$"); err != nil {
+			t.Fatalf("CreateConsumerGroup: %v", err)
+		}
+		evs := []state.Event{
+			{Type: "sub-type-1", AgentID: "sub-agent-1", TaskID: "sub-task-1"},
+			{Type: "sub-type-2", AgentID: "sub-agent-2", TaskID: "sub-task-2"},
+			{Type: "sub-type-3", AgentID: "sub-agent-3", TaskID: "sub-task-3"},
+		}
+		for _, ev := range evs {
+			if err := store.PublishEvent(ctx, ev); err != nil {
+				t.Fatalf("PublishEvent: %v", err)
+			}
+		}
+		got, err := store.SubscribeEvents(ctx, "cg-sub", "w1", 10, 0)
+		if err != nil {
+			t.Fatalf("SubscribeEvents: %v", err)
+		}
+		if len(got) != 3 {
+			t.Fatalf("want 3 events, got %d", len(got))
+		}
+	})
+
+	t.Run("Competing consumers receive distinct events", func(t *testing.T) {
+		// Create group at the current tail BEFORE publishing so both consumers
+		// only see our 6 events (works for mock and Redis alike).
+		if err := store.CreateConsumerGroup(ctx, "cg-compete", "$"); err != nil {
+			t.Fatalf("CreateConsumerGroup: %v", err)
+		}
+
+		for i := 1; i <= 6; i++ {
+			ev := state.Event{
+				Type:    "compete-type",
+				AgentID: fmt.Sprintf("compete-agent-%d", i),
+				TaskID:  fmt.Sprintf("compete-task-%d", i),
+			}
+			if err := store.PublishEvent(ctx, ev); err != nil {
+				t.Fatalf("PublishEvent: %v", err)
+			}
+		}
+
+		c1, err := store.SubscribeEvents(ctx, "cg-compete", "c1", 3, 0)
+		if err != nil {
+			t.Fatalf("SubscribeEvents c1: %v", err)
+		}
+		c2, err := store.SubscribeEvents(ctx, "cg-compete", "c2", 3, 0)
+		if err != nil {
+			t.Fatalf("SubscribeEvents c2: %v", err)
+		}
+
+		total := len(c1) + len(c2)
+		if total != 6 {
+			t.Fatalf("want 6 total events across consumers, got %d (c1=%d, c2=%d)", total, len(c1), len(c2))
+		}
+		seen := make(map[string]bool)
+		for _, ev := range c1 {
+			if seen[ev.ID] {
+				t.Fatalf("duplicate event ID %q in c1", ev.ID)
+			}
+			seen[ev.ID] = true
+		}
+		for _, ev := range c2 {
+			if seen[ev.ID] {
+				t.Fatalf("event ID %q delivered to both consumers", ev.ID)
+			}
+			seen[ev.ID] = true
+		}
+	})
+
+	t.Run("Acked events are not re-delivered", func(t *testing.T) {
+		// Create the group at the current tail BEFORE publishing, then publish
+		// 2 events. This works for both mock ("$" → len(streamEvents)) and Redis.
+		if err := store.CreateConsumerGroup(ctx, "cg-ack", "$"); err != nil {
+			t.Fatalf("CreateConsumerGroup: %v", err)
+		}
+
+		evs := []state.Event{
+			{Type: "ack-type-1", AgentID: "ack-agent-1", TaskID: "ack-task-1"},
+			{Type: "ack-type-2", AgentID: "ack-agent-2", TaskID: "ack-task-2"},
+		}
+		for _, ev := range evs {
+			if err := store.PublishEvent(ctx, ev); err != nil {
+				t.Fatalf("PublishEvent: %v", err)
+			}
+		}
+
+		first, err := store.SubscribeEvents(ctx, "cg-ack", "w1", 10, 0)
+		if err != nil {
+			t.Fatalf("SubscribeEvents (1st): %v", err)
+		}
+		if len(first) != 2 {
+			t.Fatalf("want 2 events on first subscribe, got %d", len(first))
+		}
+
+		ids := make([]string, len(first))
+		for i, ev := range first {
+			ids[i] = ev.ID
+		}
+		if err := store.AckEvent(ctx, "cg-ack", ids...); err != nil {
+			t.Fatalf("AckEvent: %v", err)
+		}
+
+		second, err := store.SubscribeEvents(ctx, "cg-ack", "w1", 10, 0)
+		if err != nil {
+			t.Fatalf("SubscribeEvents (2nd): %v", err)
+		}
+		if len(second) != 0 {
+			t.Fatalf("want 0 events after ack, got %d", len(second))
 		}
 	})
 }


### PR DESCRIPTION
Closes #17

## Summary
- Add `ReadEvents` method for one-shot XREAD consumption of the event stream
- Add `CreateConsumerGroup` for idempotent consumer group creation on the event stream
- Add `SubscribeEvents` method for XREADGROUP competing-consumer delivery
- Add `AckEvent` method for acknowledging processed events (XACK)
- Introduce `StreamEvent` wrapper type (Event + Redis stream entry ID) returned by all read methods
- Implement all new methods in both RedisStore and MockStore
- Add conformance tests and a competing-consumer Redis integration test
- Fix mock `SubscribeEvents` to honor `block` parameter (context-aware polling)
- Document mock `ReadEvents` cursor limitation (exact-match, not lower-bound)

## Deferred
- **"Unacked events can be reclaimed" scenario** is deferred — requires future XCLAIM/XAUTOCLAIM interface additions. The Gherkin scenario in the spec has been annotated as Future / Out of Scope.

## Spec
See `event-stream-consumption-spec.md` in the branch root for full acceptance criteria, technical plan, and task breakdown.

## Test plan
- [x] ReadEvents returns published events with correct payloads and non-empty IDs
- [x] ReadEvents with cursor returns only events after the cursor
- [x] ReadEvents on empty stream returns empty slice without error
- [x] CreateConsumerGroup is idempotent (double-create succeeds)
- [x] SubscribeEvents delivers events to a consumer in a group
- [x] Competing consumers receive distinct (non-overlapping) events
- [x] Acked events are not re-delivered on subsequent SubscribeEvents calls
- [ ] ~~Unacked events can be reclaimed by another consumer~~ (deferred — requires XCLAIM)
- [x] All conformance tests pass on both MockStore and RedisStore
- [x] Competing-consumer integration test passes against real Redis

## Council Review
Adversarial council (1 advocate, 2 critics, 3 rounds) returned **CONDITIONAL MERGE**. All fixes applied. See `2026-03-25-080000-council-pr-23-event-stream-consumption.md`.