### PR TITLE
feat: Config Loader & Fallback Chains (T5, T6)

### DIFF
--- a/config-loader-fallback-chains-spec.md
+++ b/config-loader-fallback-chains-spec.md
@@ -1,0 +1,422 @@
+# Feature: Config Loader & Fallback Chains (T5, T6)
+
+## Overview
+
+**User Story**: As an orchestrator operator, I want to define tier-to-model mappings, provider
+settings, and fallback chains in a YAML file that I can change without modifying code, so that
+I can adapt the gateway to new providers and models without a redeployment.
+
+**Problem**: Without an external configuration file, every change to model assignments, fallback
+ordering, or per-provider settings requires a code edit and recompile. Operators cannot tune
+cost/performance tradeoffs at runtime, and provider outages cannot be mitigated by adjusting
+fallback chains without touching source. Additionally, there is no retry logic: if the primary
+model returns an error, the request fails entirely instead of being retried with the next
+provider in a configured chain.
+
+**Out of Scope**:
+- Dynamic hot-reload of `models.yaml` without restart (YAML is parsed once at startup)
+- Provider API key management — keys are injected via environment variables, not stored in YAML
+- Judge-router logic and task classification (T4)
+- Cost reporting and aggregation (T7)
+- Orchestrator wiring and end-to-end integration tests (T8, T9)
+
+---
+
+## Open Questions
+
+| # | Question | Raised By | Resolved |
+|:--|:---------|:----------|:---------|
+| 1 | Should `models.yaml` include API keys, or should those always come from env vars? | T5 planning | [ ] |
+| 2 | Should `ValidateConfig` cross-check that every model in a fallback chain appears in some provider's model list? | T5 planning | [ ] |
+| 3 | Should `FallbackCompleter.chainForModel` treat an unknown-tier model as a single-entry chain (no fallback) or hard-fail immediately? | T6 planning | [ ] |
+| 4 | Should transient errors (network timeout) trigger fallback, while permanent errors (invalid API key) short-circuit the chain? | T6 planning | [ ] |
+
+---
+
+## Scope
+
+### Must-Have
+- **`config/models.yaml`** — operator-editable YAML file with: top-level gateway settings
+  (`litellm_base_url`, `timeout_seconds`), three tier definitions (`cheap`, `mid`, `frontier`)
+  each with a `primary_model` and `fallback_chain`, per-provider `base_url` and `models` list,
+  and a `cost_per_million_tokens` pricing table keyed by model name
+- **`GatewayConfig`, `GatewaySettings`, `TokenCost` types** — strongly typed Go structs that
+  hold the parsed config; must not duplicate any types already defined in `gateway.go`
+- **`LoadConfig(path string) (GatewayConfig, error)`** — reads YAML from disk and returns a
+  fully parsed `GatewayConfig`
+- **`ValidateConfig(cfg GatewayConfig) error`** — validates required fields, positive timeout,
+  at least one tier, and that every tier's `primary_model` is non-empty; returns a wrapped
+  `ErrConfigInvalid` sentinel on failure
+- **`FallbackCompleter` struct** — wraps a map of model-name → `Completer` instances plus a
+  `GatewayConfig`; implements the `Completer` interface
+- **`FallbackCompleter.Complete`** — resolves the model in the request to its tier, builds the
+  ordered chain `[primary, ...fallback_chain]`, tries each in sequence, sets `FallbackUsed=true`
+  when a fallback (index > 0) serves the request, returns `*FallbackError` if all fail
+- **`FallbackCompleter.CompleteWithTier`** — resolves a `ModelTier` to its primary model and
+  chain directly, overriding any model set on the request; validates tier before attempting
+- **`ErrNoProvider` for unknown models** — `Complete` must return `ErrNoProvider` when the
+  requested model is neither a primary model in any tier nor registered in the completers map
+
+### Should-Have
+- **`NewFallbackCompleter` constructor** — functional constructor accepting a completers map and
+  a `GatewayConfig`; enables dependency injection and clean testing
+- **Partial-chain degradation** — if a model in the chain has no registered `Completer`, it is
+  skipped with a `ProviderError` rather than panicking; the chain continues to the next entry
+
+### Nice-to-Have
+- **Config schema documentation** — inline YAML comments in `models.yaml` explaining each field
+- **`ValidateConfig` cross-checks fallback chains** — warns if a model in a fallback chain is
+  not listed under any known provider
+
+---
+
+## Technical Plan
+
+### Affected Components
+
+| File | Change |
+|:-----|:-------|
+| `config/models.yaml` | New file — full gateway YAML schema |
+| `internal/gateway/config.go` | New file — `GatewayConfig`, `GatewaySettings`, `TokenCost`, `LoadConfig`, `parseConfig`, `ValidateConfig` |
+| `internal/gateway/fallback.go` | New file — `FallbackCompleter`, `NewFallbackCompleter`, `Complete`, `CompleteWithTier`, `chainForModel`, `tryChain` |
+| `internal/gateway/config_test.go` | New file — table-driven tests for `parseConfig` and `ValidateConfig` |
+| `internal/gateway/fallback_test.go` | New file — table-driven tests for all `FallbackCompleter` scenarios |
+| `go.mod` / `go.sum` | Add `gopkg.in/yaml.v3` dependency |
+
+### YAML Schema (`config/models.yaml`)
+
+```yaml
+gateway:
+  litellm_base_url: "http://localhost:4000"   # LiteLLM proxy endpoint
+  timeout_seconds: 30                          # per-request HTTP timeout
+
+tiers:
+  cheap:
+    primary_model: "claude-haiku-4-5-20251001"
+    fallback_chain:
+      - "gpt-4o-mini"
+      - "ollama/llama3"
+  mid:
+    primary_model: "claude-sonnet-4-6"
+    fallback_chain:
+      - "gpt-4o"
+      - "gemini-pro"
+  frontier:
+    primary_model: "claude-opus-4-6"
+    fallback_chain:
+      - "gpt-4o"
+      - "claude-sonnet-4-6"
+
+providers:
+  anthropic:
+    base_url: "https://api.anthropic.com"
+    models: ["claude-haiku-4-5-20251001", "claude-sonnet-4-6", "claude-opus-4-6"]
+  openai:
+    base_url: "https://api.openai.com"
+    models: ["gpt-4o", "gpt-4o-mini"]
+  ollama:
+    base_url: "http://localhost:11434"
+    models: ["ollama/llama3", "ollama/codellama"]
+  gemini:
+    base_url: "https://generativelanguage.googleapis.com"
+    models: ["gemini-pro"]
+
+cost_per_million_tokens:
+  claude-haiku-4-5-20251001: { input: 0.80,  output: 4.00  }
+  claude-sonnet-4-6:         { input: 3.00,  output: 15.00 }
+  claude-opus-4-6:           { input: 15.00, output: 75.00 }
+  gpt-4o:                    { input: 2.50,  output: 10.00 }
+  gpt-4o-mini:               { input: 0.15,  output: 0.60  }
+  gemini-pro:                { input: 1.25,  output: 5.00  }
+  ollama/llama3:             { input: 0.0,   output: 0.0   }
+  ollama/codellama:          { input: 0.0,   output: 0.0   }
+```
+
+**Design notes**:
+- Provider API keys are NOT in this file — they must be injected via environment variables
+  (`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, etc.) read at provider construction time
+- `base_url` for each provider overrides the LiteLLM default for direct HTTP usage
+- Tier keys must match the `ModelTier` constants (`cheap`, `mid`, `frontier`)
+- Cost values of `0.0` for Ollama models reflect local inference with no API billing
+
+### Go Types
+
+```go
+// config.go
+
+// GatewaySettings holds top-level connection settings for the gateway.
+type GatewaySettings struct {
+    LiteLLMBaseURL string `yaml:"litellm_base_url"`
+    TimeoutSeconds int    `yaml:"timeout_seconds"`
+}
+
+// TokenCost holds per-million-token pricing for a model.
+type TokenCost struct {
+    Input  float64 `yaml:"input"`
+    Output float64 `yaml:"output"`
+}
+
+// GatewayConfig is the fully parsed gateway configuration.
+// TierConfig and ProviderConfig are defined in gateway.go.
+type GatewayConfig struct {
+    Gateway              GatewaySettings           `yaml:"gateway"`
+    Tiers                map[ModelTier]TierConfig  `yaml:"tiers"`
+    Providers            map[string]ProviderConfig `yaml:"providers"`
+    CostPerMillionTokens map[string]TokenCost      `yaml:"cost_per_million_tokens"`
+}
+```
+
+**Note**: `TierConfig` and `ProviderConfig` are already defined in `gateway.go` (T1). The YAML
+layer uses internal raw structs (`rawTierConfig`, `rawProviderConfig`) because `yaml.v3` cannot
+unmarshal directly into `ModelTier` map keys; the `parseConfig` function performs the conversion.
+
+### Go Functions
+
+```go
+// config.go
+
+// LoadConfig reads and parses the YAML configuration at path.
+// Returns a wrapped ErrConfigInvalid if the file is unreadable or malformed.
+func LoadConfig(path string) (GatewayConfig, error)
+
+// parseConfig parses raw YAML bytes into a GatewayConfig.
+// Converts string tier keys to ModelTier and string provider keys to ProviderConfig.
+// Not exported — called by LoadConfig and directly in tests.
+func parseConfig(data []byte) (GatewayConfig, error)
+
+// ValidateConfig checks that required fields are present and internally consistent.
+// Returns a wrapped ErrConfigInvalid describing the first violation found.
+// Rules:
+//   - gateway.litellm_base_url must be non-empty
+//   - gateway.timeout_seconds must be > 0
+//   - at least one tier must be defined
+//   - every tier key must be a valid ModelTier (cheap/mid/frontier)
+//   - every tier must have a non-empty primary_model
+func ValidateConfig(cfg GatewayConfig) error
+```
+
+```go
+// fallback.go
+
+// FallbackCompleter wraps a set of per-model Completers and applies the
+// fallback chain defined in GatewayConfig when the primary model fails.
+type FallbackCompleter struct {
+    completers map[string]Completer
+    config     GatewayConfig
+}
+
+// NewFallbackCompleter returns a FallbackCompleter backed by the given
+// model-keyed completers and configuration.
+func NewFallbackCompleter(completers map[string]Completer, config GatewayConfig) *FallbackCompleter
+
+// Complete resolves the model in req to a tier, then attempts the primary
+// model and each fallback in order. The first success is returned with
+// FallbackUsed=true when a non-primary model served the request.
+// Returns *FallbackError if all providers fail.
+// Returns ErrNoProvider if the model is not found in any tier or completer map.
+func (fc *FallbackCompleter) Complete(ctx context.Context, req CompletionRequest) (CompletionResponse, error)
+
+// CompleteWithTier resolves tier to its primary model, then attempts the
+// primary model and each fallback in order.
+// Returns ErrInvalidTier for unrecognised or unconfigured tiers.
+func (fc *FallbackCompleter) CompleteWithTier(ctx context.Context, tier ModelTier, req CompletionRequest) (CompletionResponse, error)
+```
+
+### Dependencies
+
+| Package | Version | Purpose |
+|:--------|:--------|:--------|
+| `gopkg.in/yaml.v3` | latest | YAML parsing for `models.yaml` |
+| `context` | stdlib | Context propagation through completion calls |
+| `errors` | stdlib | `errors.As` for `ProviderError` unwrapping |
+| `fmt` | stdlib | Error formatting with sentinel wrapping |
+| `os` | stdlib | `os.ReadFile` in `LoadConfig` |
+
+### Risks
+
+| Risk | Likelihood | Mitigation |
+|:-----|:-----------|:-----------|
+| `yaml.v3` cannot unmarshal `ModelTier` map keys directly (string → custom type) | High (known Go limitation) | Use intermediate `rawGatewayConfig` with `map[string]...` keys; convert in `parseConfig` |
+| Operator misconfigures fallback chain with a model name that has no registered `Completer` | Medium | `tryChain` records a `ProviderError` and skips the entry rather than panicking; `ValidateConfig` can optionally cross-check |
+| All models in a tier chain use the same upstream provider (no actual redundancy) | Low-Medium | Document recommendation in `models.yaml` comments; operator responsibility |
+| Context cancellation mid-chain stops all remaining fallback attempts | Low | `tryChain` must check `ctx.Err()` before each attempt and short-circuit on cancellation |
+
+---
+
+## Acceptance Scenarios
+
+```gherkin
+Feature: Config Loader & Fallback Chains
+  As an orchestrator operator
+  I want gateway configuration loaded from YAML and fallback retry on provider failure
+  So that I can tune model assignments without code changes and survive provider outages
+
+  Background:
+    Given "config/models.yaml" defines three tiers: cheap (Haiku), mid (Sonnet), frontier (Opus)
+    And each tier has a primary_model and a fallback_chain of two alternative models
+    And four providers are configured: anthropic, openai, ollama, gemini
+
+  Rule: Config loading
+
+    Scenario: Valid config loads successfully
+      Given "config/models.yaml" contains all required fields
+      When LoadConfig is called with the path
+      Then it returns a GatewayConfig with no error
+      And cfg.Gateway.LiteLLMBaseURL equals "http://localhost:4000"
+      And cfg.Gateway.TimeoutSeconds equals 30
+      And cfg.Tiers["cheap"].PrimaryModel equals "claude-haiku-4-5-20251001"
+      And cfg.Tiers["mid"].FallbackChain contains ["gpt-4o", "gemini-pro"]
+      And cfg.CostPerMillionTokens["claude-opus-4-6"].Output equals 75.00
+
+    Scenario: Config with missing litellm_base_url fails validation
+      Given a GatewayConfig where gateway.litellm_base_url is empty
+      When ValidateConfig is called
+      Then it returns an error wrapping ErrConfigInvalid
+      And the error message mentions "litellm_base_url"
+
+    Scenario: Config with zero timeout fails validation
+      Given a GatewayConfig where gateway.timeout_seconds is 0
+      When ValidateConfig is called
+      Then it returns an error wrapping ErrConfigInvalid
+      And the error message mentions "timeout_seconds"
+
+    Scenario: Config with no tiers fails validation
+      Given a GatewayConfig with an empty tiers map
+      When ValidateConfig is called
+      Then it returns an error wrapping ErrConfigInvalid
+      And the error message mentions "tier"
+
+    Scenario: Config with a tier missing its primary_model fails validation
+      Given a GatewayConfig where the "mid" tier has an empty primary_model
+      When ValidateConfig is called
+      Then it returns an error wrapping ErrConfigInvalid
+      And the error message mentions "primary_model"
+
+    Scenario: Config with malformed YAML returns parse error
+      Given a YAML file containing invalid syntax
+      When LoadConfig is called with that path
+      Then it returns an error wrapping ErrConfigInvalid
+
+  Rule: Fallback chain — primary succeeds
+
+    Scenario: Primary model succeeds on first attempt
+      Given a FallbackCompleter configured with the mid tier (primary: claude-sonnet-4-6)
+      And the claude-sonnet-4-6 completer returns a successful response
+      When Complete is called with Model "claude-sonnet-4-6"
+      Then the response is returned with FallbackUsed equal to false
+      And the ProviderName in the response is "anthropic"
+
+  Rule: Fallback chain — primary fails, fallback succeeds
+
+    Scenario: Primary provider returns HTTP 500, first fallback succeeds
+      Given a FallbackCompleter configured with the mid tier
+      And the claude-sonnet-4-6 completer returns a ProviderError (HTTP 500)
+      And the gpt-4o completer returns a successful response
+      When Complete is called with Model "claude-sonnet-4-6"
+      Then the response is returned successfully
+      And FallbackUsed is true
+      And the ProviderName in the response is "openai"
+
+    Scenario: First and second providers fail, third fallback succeeds
+      Given a FallbackCompleter configured with the mid tier
+      And claude-sonnet-4-6 returns a ProviderError
+      And gpt-4o returns a ProviderError
+      And gemini-pro returns a successful response
+      When Complete is called with Model "claude-sonnet-4-6"
+      Then the response is returned successfully
+      And FallbackUsed is true
+      And the ProviderName in the response is "gemini"
+
+  Rule: Fallback chain — all providers fail
+
+    Scenario: All providers in the chain fail
+      Given a FallbackCompleter configured with the mid tier
+      And claude-sonnet-4-6, gpt-4o, and gemini-pro all return ProviderErrors
+      When Complete is called with Model "claude-sonnet-4-6"
+      Then a *FallbackError is returned
+      And the FallbackError.Errors slice contains three ProviderErrors
+      And errors.Is(err, ErrAllProvidersFailed) returns true
+
+  Rule: Unknown model
+
+    Scenario: Request for a model not found in any tier or completer
+      Given a FallbackCompleter with no completer registered for "unknown-model-xyz"
+      And "unknown-model-xyz" is not the primary_model of any tier
+      When Complete is called with Model "unknown-model-xyz"
+      Then ErrNoProvider is returned
+      And no completion attempt is made
+
+  Rule: CompleteWithTier routing
+
+    Scenario: CompleteWithTier resolves tier to primary model
+      Given a FallbackCompleter with the cheap tier configured
+      And the claude-haiku-4-5-20251001 completer returns a successful response
+      When CompleteWithTier is called with tier "cheap" and an empty model field
+      Then the request is forwarded to the claude-haiku-4-5-20251001 completer
+      And the response is returned with FallbackUsed equal to false
+
+    Scenario: CompleteWithTier with an invalid tier returns ErrInvalidTier
+      Given a FallbackCompleter
+      When CompleteWithTier is called with tier "premium"
+      Then ErrInvalidTier is returned
+      And no completion attempt is made
+
+    Scenario: CompleteWithTier falls through to fallback when primary fails
+      Given a FallbackCompleter with the cheap tier configured
+      And claude-haiku-4-5-20251001 returns a ProviderError
+      And gpt-4o-mini returns a successful response
+      When CompleteWithTier is called with tier "cheap"
+      Then the response is returned successfully
+      And FallbackUsed is true
+```
+
+---
+
+## Task Breakdown
+
+| ID | Task | Priority | Dependencies | Status |
+|:---|:-----|:---------|:-------------|:-------|
+| T5a | Define `GatewaySettings`, `TokenCost`, `GatewayConfig` types in `config.go` | High | T1 | pending |
+| T5b | Implement `parseConfig` (YAML → domain types, raw intermediate structs) | High | T5a | pending |
+| T5c | Implement `LoadConfig(path)` (file I/O → `parseConfig`) | High | T5b | pending |
+| T5d | Implement `ValidateConfig` (required fields, tier invariants) | High | T5a | pending |
+| T5e | Write `config/models.yaml` with full schema (three tiers, four providers, pricing table) | High | T5a | pending |
+| T5f | Write table-driven tests for `parseConfig` and `ValidateConfig` | High | T5b, T5d | pending |
+| T6a | Implement `FallbackCompleter` struct and `NewFallbackCompleter` constructor | High | T1, T5 | pending |
+| T6b | Implement `chainForModel` (model → tier lookup → ordered chain) | High | T6a | pending |
+| T6c | Implement `tryChain` (iterate chain, accumulate `ProviderError`s, set `FallbackUsed`) | High | T6a | pending |
+| T6d | Implement `Complete` (delegates to `chainForModel` + `tryChain`) | High | T6b, T6c | pending |
+| T6e | Implement `CompleteWithTier` (tier → primary + chain, validates tier first) | High | T6c | pending |
+| T6f | Write table-driven tests for all fallback scenarios (primary ok, partial fallback, total failure, unknown model, tier routing) | High | T6d, T6e | pending |
+
+---
+
+## Exit Criteria
+
+- [ ] `LoadConfig("config/models.yaml")` returns a valid `GatewayConfig` with no error when the
+  file contains all required fields
+- [ ] `ValidateConfig` rejects configs missing `litellm_base_url`, non-positive `timeout_seconds`,
+  empty tier map, or a tier without a `primary_model` — each with a wrapped `ErrConfigInvalid`
+- [ ] `FallbackCompleter.Complete` returns `FallbackUsed=false` when the primary model succeeds
+- [ ] `FallbackCompleter.Complete` returns `FallbackUsed=true` and the correct `ProviderName`
+  when any fallback serves the request
+- [ ] `FallbackCompleter.Complete` returns a `*FallbackError` (wrapping `ErrAllProvidersFailed`)
+  when all providers in the chain fail, with one `ProviderError` per provider in the list
+- [ ] `FallbackCompleter.Complete` returns `ErrNoProvider` for an unknown model
+- [ ] `FallbackCompleter.CompleteWithTier` resolves tier to primary model and applies the same
+  fallback logic; returns `ErrInvalidTier` for unrecognised tiers
+- [ ] All tests pass under `go test ./internal/gateway/...` with `-race`
+- [ ] No mutations of shared state (immutable request copies passed to each `Completer`)
+
+---
+
+## References
+
+- Epic spec: `specs/model-gateway-spec.md`
+- Gateway interface and types: `internal/gateway/gateway.go` (T1)
+- Error sentinels (`ErrNoProvider`, `ErrAllProvidersFailed`, `ErrConfigInvalid`, `FallbackError`, `ProviderError`): `internal/gateway/errors.go` (T1)
+- GitHub issue: #37
+
+---
+
+*Authored by: Clault KiperS 4.6*

--- a/config/models.yaml
+++ b/config/models.yaml
@@ -1,29 +1,44 @@
+gateway:
+  litellm_base_url: "http://localhost:4000"
+  timeout_seconds: 30
+
 tiers:
-  haiku:
-    models:
-      - claude-haiku-4-5-20251001
-    description: Lightweight agents, frequent invocation, worker agents
-    cost_class: low
+  cheap:
+    primary_model: "claude-haiku-4-5-20251001"
+    fallback_chain:
+      - "gpt-4o-mini"
+      - "ollama/llama3"
+  mid:
+    primary_model: "claude-sonnet-4-6"
+    fallback_chain:
+      - "gpt-4o"
+      - "gemini-pro"
+  frontier:
+    primary_model: "claude-opus-4-6"
+    fallback_chain:
+      - "gpt-4o"
+      - "claude-sonnet-4-6"
 
-  sonnet:
-    models:
-      - claude-sonnet-4-6
-    description: Main development work, orchestration, complex coding
-    cost_class: medium
+providers:
+  anthropic:
+    base_url: "https://api.anthropic.com"
+    models: ["claude-haiku-4-5-20251001", "claude-sonnet-4-6", "claude-opus-4-6"]
+  openai:
+    base_url: "https://api.openai.com"
+    models: ["gpt-4o", "gpt-4o-mini"]
+  ollama:
+    base_url: "http://localhost:11434"
+    models: ["ollama/llama3", "ollama/codellama"]
+  gemini:
+    base_url: "https://generativelanguage.googleapis.com"
+    models: ["gemini-pro"]
 
-  opus:
-    models:
-      - claude-opus-4-6
-    description: Complex architectural decisions, maximum reasoning
-    cost_class: high
-
-fallback_chains:
-  opus:
-    - opus
-    - sonnet
-    - haiku
-  sonnet:
-    - sonnet
-    - haiku
-  haiku:
-    - haiku
+cost_per_million_tokens:
+  claude-haiku-4-5-20251001: { input: 0.80, output: 4.00 }
+  claude-sonnet-4-6: { input: 3.00, output: 15.00 }
+  claude-opus-4-6: { input: 15.00, output: 75.00 }
+  gpt-4o: { input: 2.50, output: 10.00 }
+  gpt-4o-mini: { input: 0.15, output: 0.60 }
+  gemini-pro: { input: 1.25, output: 5.00 }
+  ollama/llama3: { input: 0.0, output: 0.0 }
+  ollama/codellama: { input: 0.0, output: 0.0 }

--- a/go.mod
+++ b/go.mod
@@ -17,4 +17,5 @@ require (
 	golang.org/x/sys v0.39.0 // indirect
 	golang.org/x/text v0.32.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20251202230838-ff82c1b0f217 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -56,3 +56,6 @@ google.golang.org/grpc v1.79.2 h1:fRMD94s2tITpyJGtBBn7MkMseNpOZU8ZxgC3MMBaXRU=
 google.golang.org/grpc v1.79.2/go.mod h1:KmT0Kjez+0dde/v2j9vzwoAScgEPx/Bw1CYChhHLrHQ=
 google.golang.org/protobuf v1.36.11 h1:fV6ZwhNocDyBLK0dj+fg8ektcVegBBuEolpbTQyBNVE=
 google.golang.org/protobuf v1.36.11/go.mod h1:HTf+CrKn2C3g5S8VImy6tdcUvCska2kB7j23XfzDpco=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/gateway/config.go
+++ b/internal/gateway/config.go
@@ -51,7 +51,7 @@ type rawGatewayConfig struct {
 func LoadConfig(path string) (GatewayConfig, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
-		return GatewayConfig{}, fmt.Errorf("gateway: read config %q: %w", path, err)
+		return GatewayConfig{}, fmt.Errorf("%w: read config %q: %v", ErrConfigInvalid, path, err)
 	}
 	return parseConfig(data)
 }
@@ -104,14 +104,6 @@ func ValidateConfig(cfg GatewayConfig) error {
 	}
 	if len(cfg.Tiers) == 0 {
 		return fmt.Errorf("%w: at least one tier must be defined", ErrConfigInvalid)
-	}
-
-	// Build a set of all declared model names for reference checks.
-	allModels := make(map[string]struct{})
-	for _, pc := range cfg.Providers {
-		for _, m := range pc.Models {
-			allModels[m] = struct{}{}
-		}
 	}
 
 	for tier, tc := range cfg.Tiers {

--- a/internal/gateway/config.go
+++ b/internal/gateway/config.go
@@ -1,0 +1,127 @@
+package gateway
+
+import (
+	"fmt"
+	"os"
+
+	"gopkg.in/yaml.v3"
+)
+
+// GatewaySettings holds top-level connection settings for the gateway.
+type GatewaySettings struct {
+	LiteLLMBaseURL string `yaml:"litellm_base_url"`
+	TimeoutSeconds int    `yaml:"timeout_seconds"`
+}
+
+// TokenCost holds per-million-token pricing for a model.
+type TokenCost struct {
+	Input  float64 `yaml:"input"`
+	Output float64 `yaml:"output"`
+}
+
+// GatewayConfig is the fully parsed gateway configuration.
+type GatewayConfig struct {
+	Gateway              GatewaySettings           `yaml:"gateway"`
+	Tiers                map[ModelTier]TierConfig  `yaml:"tiers"`
+	Providers            map[string]ProviderConfig `yaml:"providers"`
+	CostPerMillionTokens map[string]TokenCost      `yaml:"cost_per_million_tokens"`
+}
+
+// rawTierConfig is the YAML shape for a tier entry.
+type rawTierConfig struct {
+	PrimaryModel  string   `yaml:"primary_model"`
+	FallbackChain []string `yaml:"fallback_chain"`
+}
+
+// rawProviderConfig is the YAML shape for a provider entry.
+type rawProviderConfig struct {
+	BaseURL string   `yaml:"base_url"`
+	Models  []string `yaml:"models"`
+}
+
+// rawGatewayConfig mirrors the YAML file before conversion to domain types.
+type rawGatewayConfig struct {
+	Gateway              GatewaySettings              `yaml:"gateway"`
+	Tiers                map[string]rawTierConfig     `yaml:"tiers"`
+	Providers            map[string]rawProviderConfig `yaml:"providers"`
+	CostPerMillionTokens map[string]TokenCost         `yaml:"cost_per_million_tokens"`
+}
+
+// LoadConfig reads and parses the YAML configuration at path.
+func LoadConfig(path string) (GatewayConfig, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return GatewayConfig{}, fmt.Errorf("gateway: read config %q: %w", path, err)
+	}
+	return parseConfig(data)
+}
+
+// parseConfig parses raw YAML bytes into a GatewayConfig.
+func parseConfig(data []byte) (GatewayConfig, error) {
+	var raw rawGatewayConfig
+	if err := yaml.Unmarshal(data, &raw); err != nil {
+		return GatewayConfig{}, fmt.Errorf("%w: %v", ErrConfigInvalid, err)
+	}
+
+	cfg := GatewayConfig{
+		Gateway:              raw.Gateway,
+		Tiers:                make(map[ModelTier]TierConfig, len(raw.Tiers)),
+		Providers:            make(map[string]ProviderConfig, len(raw.Providers)),
+		CostPerMillionTokens: raw.CostPerMillionTokens,
+	}
+
+	for tierName, rt := range raw.Tiers {
+		tier := ModelTier(tierName)
+		cfg.Tiers[tier] = TierConfig{
+			Tier:          tier,
+			PrimaryModel:  rt.PrimaryModel,
+			FallbackChain: rt.FallbackChain,
+		}
+	}
+
+	for name, rp := range raw.Providers {
+		cfg.Providers[name] = ProviderConfig{
+			Name:    name,
+			BaseURL: rp.BaseURL,
+			Models:  rp.Models,
+		}
+	}
+
+	if cfg.CostPerMillionTokens == nil {
+		cfg.CostPerMillionTokens = make(map[string]TokenCost)
+	}
+
+	return cfg, nil
+}
+
+// ValidateConfig checks that required fields are present and internally consistent.
+func ValidateConfig(cfg GatewayConfig) error {
+	if cfg.Gateway.LiteLLMBaseURL == "" {
+		return fmt.Errorf("%w: gateway.litellm_base_url is required", ErrConfigInvalid)
+	}
+	if cfg.Gateway.TimeoutSeconds <= 0 {
+		return fmt.Errorf("%w: gateway.timeout_seconds must be positive", ErrConfigInvalid)
+	}
+	if len(cfg.Tiers) == 0 {
+		return fmt.Errorf("%w: at least one tier must be defined", ErrConfigInvalid)
+	}
+
+	// Build a set of all declared model names for reference checks.
+	allModels := make(map[string]struct{})
+	for _, pc := range cfg.Providers {
+		for _, m := range pc.Models {
+			allModels[m] = struct{}{}
+		}
+	}
+
+	for tier, tc := range cfg.Tiers {
+		if !tier.Valid() {
+			return fmt.Errorf("%w: unknown tier %q", ErrConfigInvalid, tier)
+		}
+		if tc.PrimaryModel == "" {
+			return fmt.Errorf("%w: tier %q has no primary_model", ErrConfigInvalid, tier)
+		}
+	}
+
+	return nil
+}

--- a/internal/gateway/config.go
+++ b/internal/gateway/config.go
@@ -113,6 +113,11 @@ func ValidateConfig(cfg GatewayConfig) error {
 		if tc.PrimaryModel == "" {
 			return fmt.Errorf("%w: tier %q has no primary_model", ErrConfigInvalid, tier)
 		}
+		for i, m := range tc.FallbackChain {
+			if m == "" {
+				return fmt.Errorf("%w: tier %q fallback_chain[%d] is empty", ErrConfigInvalid, tier, i)
+			}
+		}
 	}
 
 	return nil

--- a/internal/gateway/config_test.go
+++ b/internal/gateway/config_test.go
@@ -1,0 +1,172 @@
+package gateway
+
+import (
+	"errors"
+	"testing"
+)
+
+const testYAML = `
+gateway:
+  litellm_base_url: "http://localhost:4000"
+  timeout_seconds: 30
+
+tiers:
+  cheap:
+    primary_model: "claude-haiku-4-5-20251001"
+    fallback_chain:
+      - "gpt-4o-mini"
+      - "ollama/llama3"
+  mid:
+    primary_model: "claude-sonnet-4-6"
+    fallback_chain:
+      - "gpt-4o"
+  frontier:
+    primary_model: "claude-opus-4-6"
+    fallback_chain:
+      - "gpt-4o"
+      - "claude-sonnet-4-6"
+
+providers:
+  anthropic:
+    base_url: "https://api.anthropic.com"
+    models: ["claude-haiku-4-5-20251001", "claude-sonnet-4-6", "claude-opus-4-6"]
+  openai:
+    base_url: "https://api.openai.com"
+    models: ["gpt-4o", "gpt-4o-mini"]
+  ollama:
+    base_url: "http://localhost:11434"
+    models: ["ollama/llama3"]
+
+cost_per_million_tokens:
+  claude-haiku-4-5-20251001: { input: 0.80, output: 4.00 }
+  claude-sonnet-4-6: { input: 3.00, output: 15.00 }
+  claude-opus-4-6: { input: 15.00, output: 75.00 }
+  gpt-4o: { input: 2.50, output: 10.00 }
+  gpt-4o-mini: { input: 0.15, output: 0.60 }
+  ollama/llama3: { input: 0.0, output: 0.0 }
+`
+
+func TestParseConfig(t *testing.T) {
+	cfg, err := parseConfig([]byte(testYAML))
+	if err != nil {
+		t.Fatalf("parseConfig error: %v", err)
+	}
+
+	if cfg.Gateway.LiteLLMBaseURL != "http://localhost:4000" {
+		t.Errorf("LiteLLMBaseURL = %q, want http://localhost:4000", cfg.Gateway.LiteLLMBaseURL)
+	}
+	if cfg.Gateway.TimeoutSeconds != 30 {
+		t.Errorf("TimeoutSeconds = %d, want 30", cfg.Gateway.TimeoutSeconds)
+	}
+
+	if len(cfg.Tiers) != 3 {
+		t.Fatalf("len(Tiers) = %d, want 3", len(cfg.Tiers))
+	}
+
+	cheap, ok := cfg.Tiers[TierCheap]
+	if !ok {
+		t.Fatal("missing tier cheap")
+	}
+	if cheap.PrimaryModel != "claude-haiku-4-5-20251001" {
+		t.Errorf("cheap.PrimaryModel = %q", cheap.PrimaryModel)
+	}
+	if len(cheap.FallbackChain) != 2 {
+		t.Errorf("cheap fallback chain len = %d, want 2", len(cheap.FallbackChain))
+	}
+
+	if len(cfg.Providers) != 3 {
+		t.Fatalf("len(Providers) = %d, want 3", len(cfg.Providers))
+	}
+
+	cost, ok := cfg.CostPerMillionTokens["claude-haiku-4-5-20251001"]
+	if !ok {
+		t.Fatal("missing cost for claude-haiku-4-5-20251001")
+	}
+	if cost.Input != 0.80 {
+		t.Errorf("haiku input cost = %v, want 0.80", cost.Input)
+	}
+	if cost.Output != 4.00 {
+		t.Errorf("haiku output cost = %v, want 4.00", cost.Output)
+	}
+}
+
+func TestParseConfigInvalidYAML(t *testing.T) {
+	// An unclosed quoted string causes a genuine yaml parse error.
+	_, err := parseConfig([]byte("gateway:\n  litellm_base_url: \"unclosed string\n"))
+	if err == nil {
+		t.Fatal("expected error for invalid YAML, got nil")
+	}
+	if !errors.Is(err, ErrConfigInvalid) {
+		t.Errorf("error = %v, want wrapping ErrConfigInvalid", err)
+	}
+}
+
+func TestValidateConfig(t *testing.T) {
+	tests := []struct {
+		name    string
+		mutate  func(*GatewayConfig)
+		wantErr bool
+	}{
+		{
+			name:    "valid config",
+			mutate:  func(_ *GatewayConfig) {},
+			wantErr: false,
+		},
+		{
+			name:    "missing litellm_base_url",
+			mutate:  func(c *GatewayConfig) { c.Gateway.LiteLLMBaseURL = "" },
+			wantErr: true,
+		},
+		{
+			name:    "zero timeout",
+			mutate:  func(c *GatewayConfig) { c.Gateway.TimeoutSeconds = 0 },
+			wantErr: true,
+		},
+		{
+			name:    "negative timeout",
+			mutate:  func(c *GatewayConfig) { c.Gateway.TimeoutSeconds = -1 },
+			wantErr: true,
+		},
+		{
+			name:    "no tiers",
+			mutate:  func(c *GatewayConfig) { c.Tiers = nil },
+			wantErr: true,
+		},
+		{
+			name: "tier missing primary model",
+			mutate: func(c *GatewayConfig) {
+				tc := c.Tiers[TierCheap]
+				tc.PrimaryModel = ""
+				c.Tiers[TierCheap] = tc
+			},
+			wantErr: true,
+		},
+		{
+			name: "unknown tier key",
+			mutate: func(c *GatewayConfig) {
+				c.Tiers[ModelTier("bogus")] = TierConfig{
+					Tier:         ModelTier("bogus"),
+					PrimaryModel: "some-model",
+				}
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg, err := parseConfig([]byte(testYAML))
+			if err != nil {
+				t.Fatalf("parseConfig: %v", err)
+			}
+			tt.mutate(&cfg)
+			err = ValidateConfig(cfg)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ValidateConfig() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantErr && err != nil && !errors.Is(err, ErrConfigInvalid) {
+				t.Errorf("error = %v, want wrapping ErrConfigInvalid", err)
+			}
+		})
+	}
+}

--- a/internal/gateway/config_test.go
+++ b/internal/gateway/config_test.go
@@ -2,6 +2,8 @@ package gateway
 
 import (
 	"errors"
+	"path/filepath"
+	"runtime"
 	"testing"
 )
 
@@ -168,5 +170,43 @@ func TestValidateConfig(t *testing.T) {
 				t.Errorf("error = %v, want wrapping ErrConfigInvalid", err)
 			}
 		})
+	}
+}
+
+// repoRoot returns the repository root by walking up from the test file location.
+func repoRoot(t *testing.T) string {
+	t.Helper()
+	_, filename, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("cannot determine test file path")
+	}
+	// internal/gateway/config_test.go → repo root is two dirs up
+	return filepath.Join(filepath.Dir(filename), "..", "..")
+}
+
+func TestLoadConfig(t *testing.T) {
+	path := filepath.Join(repoRoot(t), "config", "models.yaml")
+	cfg, err := LoadConfig(path)
+	if err != nil {
+		t.Fatalf("LoadConfig(%q) error: %v", path, err)
+	}
+	if cfg.Gateway.LiteLLMBaseURL != "http://localhost:4000" {
+		t.Errorf("LiteLLMBaseURL = %q, want http://localhost:4000", cfg.Gateway.LiteLLMBaseURL)
+	}
+	if cfg.Gateway.TimeoutSeconds != 30 {
+		t.Errorf("TimeoutSeconds = %d, want 30", cfg.Gateway.TimeoutSeconds)
+	}
+	if len(cfg.Tiers) != 3 {
+		t.Errorf("len(Tiers) = %d, want 3", len(cfg.Tiers))
+	}
+}
+
+func TestLoadConfig_FileNotFound(t *testing.T) {
+	_, err := LoadConfig("/nonexistent/path/models.yaml")
+	if err == nil {
+		t.Fatal("expected error for nonexistent file, got nil")
+	}
+	if !errors.Is(err, ErrConfigInvalid) {
+		t.Errorf("error = %v, want wrapping ErrConfigInvalid", err)
 	}
 }

--- a/internal/gateway/config_test.go
+++ b/internal/gateway/config_test.go
@@ -144,6 +144,15 @@ func TestValidateConfig(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name: "empty fallback chain entry",
+			mutate: func(c *GatewayConfig) {
+				tc := c.Tiers[TierCheap]
+				tc.FallbackChain = []string{"gpt-4o-mini", ""}
+				c.Tiers[TierCheap] = tc
+			},
+			wantErr: true,
+		},
+		{
 			name: "unknown tier key",
 			mutate: func(c *GatewayConfig) {
 				c.Tiers[ModelTier("bogus")] = TierConfig{

--- a/internal/gateway/errors.go
+++ b/internal/gateway/errors.go
@@ -1,6 +1,9 @@
 package gateway
 
-import "errors"
+import (
+	"context"
+	"errors"
+)
 
 var (
 	// ErrNoProvider is returned when no provider is configured for the requested model.
@@ -72,4 +75,16 @@ func (e *FallbackError) Error() string {
 	return msg
 }
 
-func (e *FallbackError) Unwrap() error { return ErrAllProvidersFailed }
+// Unwrap returns ErrAllProvidersFailed plus any context errors found in the
+// chain. This allows errors.Is(err, context.Canceled) and
+// errors.Is(err, context.DeadlineExceeded) to work transparently.
+func (e *FallbackError) Unwrap() []error {
+	errs := []error{ErrAllProvidersFailed}
+	for _, pe := range e.Errors {
+		if pe.Err != nil && (pe.Err == context.Canceled || pe.Err == context.DeadlineExceeded) {
+			errs = append(errs, pe.Err)
+			break // only one context error is possible per chain
+		}
+	}
+	return errs
+}

--- a/internal/gateway/fallback.go
+++ b/internal/gateway/fallback.go
@@ -6,6 +6,9 @@ import (
 	"fmt"
 )
 
+// Compile-time interface assertion.
+var _ Completer = (*FallbackCompleter)(nil)
+
 // FallbackCompleter wraps a set of per-model Completers and applies the
 // fallback chain defined in GatewayConfig when the primary model fails.
 type FallbackCompleter struct {
@@ -21,6 +24,9 @@ func NewFallbackCompleter(completers map[string]Completer, config GatewayConfig)
 		config:     config,
 	}
 }
+
+// Provider returns the logical provider name for this fallback dispatcher.
+func (fc *FallbackCompleter) Provider() string { return "fallback" }
 
 // Complete resolves the model in req to a tier, then attempts the primary
 // model and each fallback in order. The first success is returned.
@@ -71,6 +77,11 @@ func (fc *FallbackCompleter) tryChain(ctx context.Context, req CompletionRequest
 	var errs []ProviderError
 
 	for i, model := range chain {
+		if err := ctx.Err(); err != nil {
+			errs = append(errs, ProviderError{Provider: model, Err: err})
+			return CompletionResponse{}, &FallbackError{Errors: errs}
+		}
+
 		c, ok := fc.completers[model]
 		if !ok {
 			errs = append(errs, ProviderError{

--- a/internal/gateway/fallback.go
+++ b/internal/gateway/fallback.go
@@ -1,0 +1,101 @@
+package gateway
+
+import (
+	"context"
+	"errors"
+	"fmt"
+)
+
+// FallbackCompleter wraps a set of per-model Completers and applies the
+// fallback chain defined in GatewayConfig when the primary model fails.
+type FallbackCompleter struct {
+	completers map[string]Completer
+	config     GatewayConfig
+}
+
+// NewFallbackCompleter returns a FallbackCompleter backed by the given
+// model-keyed completers and configuration.
+func NewFallbackCompleter(completers map[string]Completer, config GatewayConfig) *FallbackCompleter {
+	return &FallbackCompleter{
+		completers: completers,
+		config:     config,
+	}
+}
+
+// Complete resolves the model in req to a tier, then attempts the primary
+// model and each fallback in order. The first success is returned.
+// If all attempts fail, a *FallbackError is returned.
+func (fc *FallbackCompleter) Complete(ctx context.Context, req CompletionRequest) (CompletionResponse, error) {
+	chain, err := fc.chainForModel(req.Model)
+	if err != nil {
+		return CompletionResponse{}, err
+	}
+	return fc.tryChain(ctx, req, chain)
+}
+
+// CompleteWithTier resolves tier to its primary model, then applies the
+// fallback chain from the tier configuration.
+func (fc *FallbackCompleter) CompleteWithTier(ctx context.Context, tier ModelTier, req CompletionRequest) (CompletionResponse, error) {
+	if !tier.Valid() {
+		return CompletionResponse{}, fmt.Errorf("%w: %q", ErrInvalidTier, tier)
+	}
+
+	tc, ok := fc.config.Tiers[tier]
+	if !ok {
+		return CompletionResponse{}, fmt.Errorf("%w: no tier config for %q", ErrInvalidTier, tier)
+	}
+
+	r := req
+	r.Model = tc.PrimaryModel
+	chain := append([]string{tc.PrimaryModel}, tc.FallbackChain...)
+	return fc.tryChain(ctx, r, chain)
+}
+
+// chainForModel returns the ordered list of models to try for the given model
+// name, looking up the tier config that owns it.
+func (fc *FallbackCompleter) chainForModel(model string) ([]string, error) {
+	for _, tc := range fc.config.Tiers {
+		if tc.PrimaryModel == model {
+			return append([]string{model}, tc.FallbackChain...), nil
+		}
+	}
+	// Model not found in any tier — still try it directly (single-entry chain).
+	if _, ok := fc.completers[model]; ok {
+		return []string{model}, nil
+	}
+	return nil, fmt.Errorf("%w: %q", ErrNoProvider, model)
+}
+
+// tryChain iterates through the model chain, returning on the first success.
+func (fc *FallbackCompleter) tryChain(ctx context.Context, req CompletionRequest, chain []string) (CompletionResponse, error) {
+	var errs []ProviderError
+
+	for i, model := range chain {
+		c, ok := fc.completers[model]
+		if !ok {
+			errs = append(errs, ProviderError{
+				Provider: model,
+				Err:      fmt.Errorf("%w: %q", ErrNoProvider, model),
+			})
+			continue
+		}
+
+		r := req
+		r.Model = model
+		resp, err := c.Complete(ctx, r)
+		if err != nil {
+			var pe *ProviderError
+			if errors.As(err, &pe) {
+				errs = append(errs, *pe)
+			} else {
+				errs = append(errs, ProviderError{Provider: c.Provider(), Err: err})
+			}
+			continue
+		}
+
+		resp.FallbackUsed = i > 0
+		return resp, nil
+	}
+
+	return CompletionResponse{}, &FallbackError{Errors: errs}
+}

--- a/internal/gateway/fallback_test.go
+++ b/internal/gateway/fallback_test.go
@@ -200,6 +200,67 @@ func TestFallbackCompleter_FallbackOnlyModel_SingleAttempt(t *testing.T) {
 	}
 }
 
+// cancelAfterNCompleter cancels the given cancel func after n calls to Complete.
+type cancelAfterNCompleter struct {
+	n      int
+	calls  int
+	cancel context.CancelFunc
+	inner  Completer
+}
+
+func (c *cancelAfterNCompleter) Complete(ctx context.Context, req CompletionRequest) (CompletionResponse, error) {
+	c.calls++
+	resp, err := c.inner.Complete(ctx, req)
+	if c.calls >= c.n {
+		c.cancel()
+	}
+	return resp, err
+}
+
+func (c *cancelAfterNCompleter) Provider() string { return c.inner.Provider() }
+
+func TestFallbackCompleter_MidChainCancellation_PreservesAccumulatedErrors(t *testing.T) {
+	cfg := testConfig()
+	ctx, cancel := context.WithCancel(context.Background())
+
+	// Primary fails normally, then context is cancelled after primary's Complete returns.
+	// The guard at fallback.go:80 should fire at i=1 with errs already containing
+	// the primary's failure.
+	primaryErr := errors.New("primary down")
+	primary := &cancelAfterNCompleter{
+		n:      1,
+		cancel: cancel,
+		inner:  &stubCompleter{provider: "p1", err: primaryErr},
+	}
+	completers := map[string]Completer{
+		"model-primary":    primary,
+		"model-fallback-1": &stubCompleter{provider: "p2", resp: CompletionResponse{Content: "should not reach"}},
+		"model-fallback-2": &stubCompleter{provider: "p3", resp: CompletionResponse{Content: "should not reach"}},
+	}
+
+	fc := NewFallbackCompleter(completers, cfg)
+	_, err := fc.Complete(ctx, CompletionRequest{Model: "model-primary"})
+	if err == nil {
+		t.Fatal("expected error for mid-chain cancellation, got nil")
+	}
+	var fe *FallbackError
+	if !errors.As(err, &fe) {
+		t.Fatalf("error type = %T, want *FallbackError", err)
+	}
+	// Should have 2 entries: primary failure + context cancellation
+	if len(fe.Errors) != 2 {
+		t.Fatalf("FallbackError.Errors len = %d, want 2", len(fe.Errors))
+	}
+	// Entry 0: primary's error
+	if fe.Errors[0].Err.Error() != "primary down" {
+		t.Errorf("fe.Errors[0].Err = %v, want 'primary down'", fe.Errors[0].Err)
+	}
+	// Entry 1: context cancellation from the guard
+	if !errors.Is(fe.Errors[1].Err, context.Canceled) {
+		t.Errorf("fe.Errors[1].Err = %v, want context.Canceled", fe.Errors[1].Err)
+	}
+}
+
 func TestFallbackCompleter_CancelledContext_StopsChain(t *testing.T) {
 	cfg := testConfig()
 	completers := map[string]Completer{
@@ -223,5 +284,29 @@ func TestFallbackCompleter_CancelledContext_StopsChain(t *testing.T) {
 	}
 	if !errors.Is(fe.Errors[0].Err, context.Canceled) {
 		t.Errorf("fe.Errors[0].Err = %v, want context.Canceled", fe.Errors[0].Err)
+	}
+}
+
+func TestFallbackError_UnwrapExposesContextCanceled(t *testing.T) {
+	cfg := testConfig()
+	completers := map[string]Completer{
+		"model-primary":    &stubCompleter{provider: "p1", resp: CompletionResponse{Content: "should not reach"}},
+		"model-fallback-1": &stubCompleter{provider: "p2", resp: CompletionResponse{Content: "should not reach"}},
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	fc := NewFallbackCompleter(completers, cfg)
+	_, err := fc.Complete(ctx, CompletionRequest{Model: "model-primary"})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	// errors.Is should now find context.Canceled through FallbackError.Unwrap
+	if !errors.Is(err, context.Canceled) {
+		t.Error("errors.Is(err, context.Canceled) = false, want true")
+	}
+	// Should still match ErrAllProvidersFailed
+	if !errors.Is(err, ErrAllProvidersFailed) {
+		t.Error("errors.Is(err, ErrAllProvidersFailed) = false, want true")
 	}
 }

--- a/internal/gateway/fallback_test.go
+++ b/internal/gateway/fallback_test.go
@@ -179,3 +179,23 @@ func TestFallbackCompleter_CompleteWithTier_InvalidTier(t *testing.T) {
 		t.Errorf("error = %v, want ErrInvalidTier", err)
 	}
 }
+
+func TestFallbackCompleter_FallbackOnlyModel_SingleAttempt(t *testing.T) {
+	cfg := testConfig()
+	// "model-fallback-1" appears only in cheap tier's fallback chain, never as a PrimaryModel.
+	completers := map[string]Completer{
+		"model-fallback-1": &stubCompleter{provider: "p2", resp: CompletionResponse{Content: "direct"}},
+	}
+
+	fc := NewFallbackCompleter(completers, cfg)
+	resp, err := fc.Complete(context.Background(), CompletionRequest{Model: "model-fallback-1"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.FallbackUsed {
+		t.Error("FallbackUsed should be false for single-entry chain")
+	}
+	if resp.Content != "direct" {
+		t.Errorf("Content = %q, want %q", resp.Content, "direct")
+	}
+}

--- a/internal/gateway/fallback_test.go
+++ b/internal/gateway/fallback_test.go
@@ -199,3 +199,29 @@ func TestFallbackCompleter_FallbackOnlyModel_SingleAttempt(t *testing.T) {
 		t.Errorf("Content = %q, want %q", resp.Content, "direct")
 	}
 }
+
+func TestFallbackCompleter_CancelledContext_StopsChain(t *testing.T) {
+	cfg := testConfig()
+	completers := map[string]Completer{
+		"model-primary":    &stubCompleter{provider: "p1", resp: CompletionResponse{Content: "should not reach"}},
+		"model-fallback-1": &stubCompleter{provider: "p2", resp: CompletionResponse{Content: "should not reach"}},
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel before calling Complete
+
+	fc := NewFallbackCompleter(completers, cfg)
+	_, err := fc.Complete(ctx, CompletionRequest{Model: "model-primary"})
+	if err == nil {
+		t.Fatal("expected error for cancelled context, got nil")
+	}
+	var fe *FallbackError
+	if !errors.As(err, &fe) {
+		t.Fatalf("error type = %T, want *FallbackError", err)
+	}
+	if len(fe.Errors) == 0 {
+		t.Fatal("FallbackError.Errors is empty, want at least one entry")
+	}
+	if !errors.Is(fe.Errors[0].Err, context.Canceled) {
+		t.Errorf("fe.Errors[0].Err = %v, want context.Canceled", fe.Errors[0].Err)
+	}
+}

--- a/internal/gateway/fallback_test.go
+++ b/internal/gateway/fallback_test.go
@@ -1,0 +1,181 @@
+package gateway
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+// stubCompleter is a test double for the Completer interface used in fallback tests.
+type stubCompleter struct {
+	provider string
+	resp     CompletionResponse
+	err      error
+}
+
+func (s *stubCompleter) Complete(_ context.Context, req CompletionRequest) (CompletionResponse, error) {
+	if s.err != nil {
+		return CompletionResponse{}, s.err
+	}
+	resp := s.resp
+	resp.Model = req.Model
+	resp.ProviderName = s.provider
+	return resp, nil
+}
+
+func (s *stubCompleter) Provider() string { return s.provider }
+
+// testConfig builds a minimal GatewayConfig for the fallback tests.
+func testConfig() GatewayConfig {
+	return GatewayConfig{
+		Gateway: GatewaySettings{
+			LiteLLMBaseURL: "http://localhost:4000",
+			TimeoutSeconds: 30,
+		},
+		Tiers: map[ModelTier]TierConfig{
+			TierCheap: {
+				Tier:          TierCheap,
+				PrimaryModel:  "model-primary",
+				FallbackChain: []string{"model-fallback-1", "model-fallback-2"},
+			},
+			TierMid: {
+				Tier:          TierMid,
+				PrimaryModel:  "model-mid",
+				FallbackChain: []string{"model-mid-fallback"},
+			},
+		},
+	}
+}
+
+func TestFallbackCompleter_PrimarySucceeds(t *testing.T) {
+	cfg := testConfig()
+	completers := map[string]Completer{
+		"model-primary":    &stubCompleter{provider: "p1", resp: CompletionResponse{Content: "hello"}},
+		"model-fallback-1": &stubCompleter{provider: "p2", err: errors.New("should not be called")},
+	}
+
+	fc := NewFallbackCompleter(completers, cfg)
+	resp, err := fc.Complete(context.Background(), CompletionRequest{Model: "model-primary"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.FallbackUsed {
+		t.Error("FallbackUsed should be false when primary succeeds")
+	}
+	if resp.Content != "hello" {
+		t.Errorf("Content = %q, want %q", resp.Content, "hello")
+	}
+}
+
+func TestFallbackCompleter_PrimaryFails_FirstFallbackSucceeds(t *testing.T) {
+	cfg := testConfig()
+	completers := map[string]Completer{
+		"model-primary":    &stubCompleter{provider: "p1", err: &ProviderError{Provider: "p1", Err: errors.New("down")}},
+		"model-fallback-1": &stubCompleter{provider: "p2", resp: CompletionResponse{Content: "fallback1"}},
+		"model-fallback-2": &stubCompleter{provider: "p3", err: errors.New("should not be called")},
+	}
+
+	fc := NewFallbackCompleter(completers, cfg)
+	resp, err := fc.Complete(context.Background(), CompletionRequest{Model: "model-primary"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !resp.FallbackUsed {
+		t.Error("FallbackUsed should be true when falling back")
+	}
+	if resp.Content != "fallback1" {
+		t.Errorf("Content = %q, want fallback1", resp.Content)
+	}
+}
+
+func TestFallbackCompleter_PrimaryAndFirstFail_SecondSucceeds(t *testing.T) {
+	cfg := testConfig()
+	completers := map[string]Completer{
+		"model-primary":    &stubCompleter{provider: "p1", err: errors.New("fail")},
+		"model-fallback-1": &stubCompleter{provider: "p2", err: errors.New("also fail")},
+		"model-fallback-2": &stubCompleter{provider: "p3", resp: CompletionResponse{Content: "fallback2"}},
+	}
+
+	fc := NewFallbackCompleter(completers, cfg)
+	resp, err := fc.Complete(context.Background(), CompletionRequest{Model: "model-primary"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !resp.FallbackUsed {
+		t.Error("FallbackUsed should be true")
+	}
+	if resp.Content != "fallback2" {
+		t.Errorf("Content = %q, want fallback2", resp.Content)
+	}
+}
+
+func TestFallbackCompleter_AllFail_ReturnsFallbackError(t *testing.T) {
+	cfg := testConfig()
+	completers := map[string]Completer{
+		"model-primary":    &stubCompleter{provider: "p1", err: errors.New("fail1")},
+		"model-fallback-1": &stubCompleter{provider: "p2", err: errors.New("fail2")},
+		"model-fallback-2": &stubCompleter{provider: "p3", err: errors.New("fail3")},
+	}
+
+	fc := NewFallbackCompleter(completers, cfg)
+	_, err := fc.Complete(context.Background(), CompletionRequest{Model: "model-primary"})
+	if err == nil {
+		t.Fatal("expected error when all providers fail")
+	}
+
+	var fe *FallbackError
+	if !errors.As(err, &fe) {
+		t.Fatalf("error = %T, want *FallbackError", err)
+	}
+	if len(fe.Errors) != 3 {
+		t.Errorf("FallbackError.Errors len = %d, want 3", len(fe.Errors))
+	}
+	if !errors.Is(err, ErrAllProvidersFailed) {
+		t.Error("error should unwrap to ErrAllProvidersFailed")
+	}
+}
+
+func TestFallbackCompleter_UnknownModel_ReturnsErrNoProvider(t *testing.T) {
+	cfg := testConfig()
+	fc := NewFallbackCompleter(map[string]Completer{}, cfg)
+
+	_, err := fc.Complete(context.Background(), CompletionRequest{Model: "unknown-model"})
+	if err == nil {
+		t.Fatal("expected error for unknown model")
+	}
+	if !errors.Is(err, ErrNoProvider) {
+		t.Errorf("error = %v, want wrapping ErrNoProvider", err)
+	}
+}
+
+func TestFallbackCompleter_CompleteWithTier_PrimarySucceeds(t *testing.T) {
+	cfg := testConfig()
+	completers := map[string]Completer{
+		"model-mid": &stubCompleter{provider: "mid", resp: CompletionResponse{Content: "mid-response"}},
+	}
+
+	fc := NewFallbackCompleter(completers, cfg)
+	resp, err := fc.CompleteWithTier(context.Background(), TierMid, CompletionRequest{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.FallbackUsed {
+		t.Error("FallbackUsed should be false")
+	}
+	if resp.Content != "mid-response" {
+		t.Errorf("Content = %q, want mid-response", resp.Content)
+	}
+}
+
+func TestFallbackCompleter_CompleteWithTier_InvalidTier(t *testing.T) {
+	cfg := testConfig()
+	fc := NewFallbackCompleter(map[string]Completer{}, cfg)
+
+	_, err := fc.CompleteWithTier(context.Background(), ModelTier("bogus"), CompletionRequest{})
+	if err == nil {
+		t.Fatal("expected error for invalid tier")
+	}
+	if !errors.Is(err, ErrInvalidTier) {
+		t.Errorf("error = %v, want ErrInvalidTier", err)
+	}
+}

--- a/internal/gateway/gateway.go
+++ b/internal/gateway/gateway.go
@@ -183,7 +183,7 @@ type ProviderConfig struct {
 	// BaseURL validation: LiteLLMClient.WithBaseURL rejects non-http/https schemes.
 	// Full host allowlist and private CIDR blocking deferred to config loading (T5).
 	BaseURL string
-	APIKey  string `json:"-"`
+	APIKey  string `json:"-" yaml:"-"`
 	Models  []string
 }
 


### PR DESCRIPTION
## Summary
- config/models.yaml with tier definitions, provider config, cost pricing
- GatewayConfig types, LoadConfig (YAML), ValidateConfig
- FallbackCompleter with Complete (model→tier→chain) and CompleteWithTier
- Sets FallbackUsed=true on fallback; returns FallbackError on total failure
- gopkg.in/yaml.v3 added as dependency

### Council fixes (d0022cc)
- LoadConfig now wraps file-read errors with ErrConfigInvalid (spec L179)
- tryChain checks ctx.Err() before each fallback attempt (spec Risks L242)
- FallbackCompleter implements Completer interface (Provider() returns "fallback")
- Removed dead allModels set from ValidateConfig
- Added TestLoadConfig, TestLoadConfig_FileNotFound, TestFallbackCompleter_FallbackOnlyModel_SingleAttempt

**Note**: Provider() on FallbackCompleter returns "fallback" as the logical adapter identifier. CompletionResponse.ProviderName carries the actual serving provider per-request. Spec prose at L51 ("implements the Completer interface") is now satisfied; the Go types plan at L198-223 should be updated to include Provider().

Closes #37

## Test plan
- [x] `go test -race ./internal/gateway/...` — all 56 tests pass
- [x] Config parsing, validation, fallback chain, LoadConfig end-to-end, fallback-only model edge case

Council review: `2026-03-27-051500-council-pr-50-config-loader-fallback-chains.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)