### PR TITLE
feat: BlockingSubmitter + CompletionRegistry for DAG completion (#72)

### DIFF
--- a/cmd/orchestrator/main.go
+++ b/cmd/orchestrator/main.go
@@ -44,7 +44,10 @@ func main() {
 	machine := agent.NewMachine(store)
 	policy := supervisor.NewRestartPolicy()
 
+	registry := supervisor.NewCompletionRegistry()
+
 	var svOpts []supervisor.SupervisorOption
+	svOpts = append(svOpts, supervisor.WithCompletionRegistry(registry))
 	if sub, err := terminal.NewTmuxSubstrate(); err != nil {
 		log.Printf("terminal substrate unavailable, running headless: %v", err)
 	} else {
@@ -57,7 +60,7 @@ func main() {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	submitter := dag.NewStoreSubmitter(store)
+	submitter := dag.NewBlockingSubmitter(store, registry)
 	executor := dag.NewExecutor(ctx, submitter)
 
 	agg := health.NewAggregator(store, executor, health.WithMinAgents(minAgents))

--- a/internal/dag/blockingsubmitter.go
+++ b/internal/dag/blockingsubmitter.go
@@ -1,0 +1,29 @@
+package dag
+
+import (
+	"context"
+
+	"github.com/Kiriketsuki/agenKic-orKistrator/internal/supervisor"
+)
+
+// BlockingSubmitter implements TaskSubmitter by enqueuing a task and then
+// blocking until the supervisor signals completion via the CompletionRegistry.
+type BlockingSubmitter struct {
+	enqueuer TaskEnqueuer
+	registry *supervisor.CompletionRegistry
+}
+
+// NewBlockingSubmitter creates a BlockingSubmitter.
+func NewBlockingSubmitter(enqueuer TaskEnqueuer, registry *supervisor.CompletionRegistry) *BlockingSubmitter {
+	return &BlockingSubmitter{enqueuer: enqueuer, registry: registry}
+}
+
+// SubmitTask enqueues the task and blocks until an agent completes it.
+func (b *BlockingSubmitter) SubmitTask(ctx context.Context, taskID, prompt, modelTier string, priority float64) error {
+	if err := b.enqueuer.EnqueueTask(ctx, taskID, priority); err != nil {
+		return err
+	}
+	err := b.registry.Wait(ctx, taskID)
+	b.registry.Cleanup(taskID)
+	return err
+}

--- a/internal/dag/blockingsubmitter_test.go
+++ b/internal/dag/blockingsubmitter_test.go
@@ -1,0 +1,71 @@
+package dag
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/Kiriketsuki/agenKic-orKistrator/internal/supervisor"
+)
+
+func TestBlockingSubmitter_BlocksUntilComplete(t *testing.T) {
+	enqueuer := &mockEnqueuer{}
+	registry := supervisor.NewCompletionRegistry()
+	sub := NewBlockingSubmitter(enqueuer, registry)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() {
+		done <- sub.SubmitTask(ctx, "task-1", "prompt", "standard", 1.0)
+	}()
+
+	time.Sleep(20 * time.Millisecond)
+	registry.Complete("task-1")
+
+	if err := <-done; err != nil {
+		t.Fatalf("expected nil, got %v", err)
+	}
+	if enqueuer.taskID != "task-1" {
+		t.Fatalf("expected task-1 to be enqueued, got %q", enqueuer.taskID)
+	}
+}
+
+func TestBlockingSubmitter_EnqueueError(t *testing.T) {
+	enqueueErr := errors.New("store unavailable")
+	enqueuer := &mockEnqueuer{err: enqueueErr}
+	registry := supervisor.NewCompletionRegistry()
+	sub := NewBlockingSubmitter(enqueuer, registry)
+
+	ctx := context.Background()
+	err := sub.SubmitTask(ctx, "task-2", "prompt", "standard", 1.0)
+	if !errors.Is(err, enqueueErr) {
+		t.Fatalf("expected enqueue error, got %v", err)
+	}
+}
+
+func TestBlockingSubmitter_ContextCancelled(t *testing.T) {
+	enqueuer := &mockEnqueuer{}
+	registry := supervisor.NewCompletionRegistry()
+	sub := NewBlockingSubmitter(enqueuer, registry)
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	done := make(chan error, 1)
+	go func() {
+		done <- sub.SubmitTask(ctx, "task-3", "prompt", "standard", 1.0)
+	}()
+
+	time.Sleep(20 * time.Millisecond)
+	cancel()
+
+	err := <-done
+	if err == nil {
+		t.Fatal("expected context error, got nil")
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context.Canceled, got %v", err)
+	}
+}

--- a/internal/dag/storesubmitter.go
+++ b/internal/dag/storesubmitter.go
@@ -10,6 +10,9 @@ type TaskEnqueuer interface {
 
 // StoreSubmitter adapts a TaskEnqueuer to the TaskSubmitter interface.
 //
+// Deprecated: StoreSubmitter is an MVP adapter that returns immediately after enqueue.
+// Use BlockingSubmitter for production DAG execution with real completion semantics.
+//
 // MVP LIMITATION: This is an enqueue-only adapter. It does NOT provide
 // completion-tracking semantics. When the DAG executor calls SubmitTask
 // and receives nil, it calls MarkNodeCompleted — but this reflects

--- a/internal/supervisor/completion.go
+++ b/internal/supervisor/completion.go
@@ -1,0 +1,65 @@
+package supervisor
+
+import (
+	"context"
+	"sync"
+)
+
+// CompletionRegistry allows callers to block until a task is completed.
+// The supervisor signals completion; the DAG executor's BlockingSubmitter waits.
+type CompletionRegistry struct {
+	mu      sync.Mutex
+	waiters map[string]chan struct{}
+}
+
+// NewCompletionRegistry creates a new CompletionRegistry.
+func NewCompletionRegistry() *CompletionRegistry {
+	return &CompletionRegistry{
+		waiters: make(map[string]chan struct{}),
+	}
+}
+
+// Wait blocks until Complete(taskID) is called or ctx is cancelled.
+// If the task was already completed before Wait is called, returns immediately.
+func (r *CompletionRegistry) Wait(ctx context.Context, taskID string) error {
+	r.mu.Lock()
+	ch, exists := r.waiters[taskID]
+	if !exists {
+		ch = make(chan struct{})
+		r.waiters[taskID] = ch
+	}
+	r.mu.Unlock()
+
+	select {
+	case <-ch:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+// Complete signals that the task is done. All waiters are unblocked.
+// Safe to call multiple times (idempotent after first call).
+func (r *CompletionRegistry) Complete(taskID string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	ch, exists := r.waiters[taskID]
+	if !exists {
+		// No waiter yet — create a pre-closed channel so future Wait returns immediately.
+		ch = make(chan struct{})
+		r.waiters[taskID] = ch
+	}
+	select {
+	case <-ch:
+		// Already closed.
+	default:
+		close(ch)
+	}
+}
+
+// Cleanup removes the entry for a task. Call after Wait returns to prevent memory leaks.
+func (r *CompletionRegistry) Cleanup(taskID string) {
+	r.mu.Lock()
+	delete(r.waiters, taskID)
+	r.mu.Unlock()
+}

--- a/internal/supervisor/completion_test.go
+++ b/internal/supervisor/completion_test.go
@@ -1,0 +1,96 @@
+package supervisor
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestCompletionRegistry_CompleteBeforeWait(t *testing.T) {
+	r := NewCompletionRegistry()
+	r.Complete("task-1")
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	if err := r.Wait(ctx, "task-1"); err != nil {
+		t.Fatalf("expected nil, got %v", err)
+	}
+}
+
+func TestCompletionRegistry_WaitThenComplete(t *testing.T) {
+	r := NewCompletionRegistry()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() {
+		done <- r.Wait(ctx, "task-2")
+	}()
+
+	time.Sleep(20 * time.Millisecond)
+	r.Complete("task-2")
+
+	if err := <-done; err != nil {
+		t.Fatalf("expected nil, got %v", err)
+	}
+}
+
+func TestCompletionRegistry_ContextCancelled(t *testing.T) {
+	r := NewCompletionRegistry()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel immediately
+
+	err := r.Wait(ctx, "task-3")
+	if err == nil {
+		t.Fatal("expected context error, got nil")
+	}
+	if err != context.Canceled {
+		t.Fatalf("expected context.Canceled, got %v", err)
+	}
+}
+
+func TestCompletionRegistry_DoubleComplete(t *testing.T) {
+	r := NewCompletionRegistry()
+
+	// Should not panic on double Complete.
+	r.Complete("task-4")
+	r.Complete("task-4")
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	if err := r.Wait(ctx, "task-4"); err != nil {
+		t.Fatalf("expected nil, got %v", err)
+	}
+}
+
+func TestCompletionRegistry_Cleanup(t *testing.T) {
+	r := NewCompletionRegistry()
+
+	// Complete and wait, then cleanup.
+	r.Complete("task-5")
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if err := r.Wait(ctx, "task-5"); err != nil {
+		t.Fatalf("Wait after Complete: %v", err)
+	}
+	r.Cleanup("task-5")
+
+	// After Cleanup, a new Wait should create a fresh channel and block until Complete.
+	done := make(chan error, 1)
+	waitCtx, waitCancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer waitCancel()
+	go func() {
+		done <- r.Wait(waitCtx, "task-5")
+	}()
+
+	time.Sleep(20 * time.Millisecond)
+	r.Complete("task-5")
+
+	if err := <-done; err != nil {
+		t.Fatalf("Wait after Cleanup+Complete: %v", err)
+	}
+}

--- a/internal/supervisor/supervisor.go
+++ b/internal/supervisor/supervisor.go
@@ -21,10 +21,11 @@ const (
 
 // Supervisor manages the agent pool: heartbeat monitoring and task assignment.
 type Supervisor struct {
-	machine   *agent.Machine
-	store     state.StateStore
-	policy    *RestartPolicy
-	substrate terminal.Substrate // optional; nil disables terminal management
+	machine            *agent.Machine
+	store              state.StateStore
+	policy             *RestartPolicy
+	substrate          terminal.Substrate  // optional; nil disables terminal management
+	completionRegistry *CompletionRegistry // optional; nil disables completion signalling
 
 	heartbeatInterval time.Duration
 	staleThreshold    time.Duration
@@ -65,6 +66,13 @@ func WithTaskPollInterval(d time.Duration) SupervisorOption {
 // and destroys it on agent crash. A nil substrate disables terminal management.
 func WithSubstrate(s terminal.Substrate) SupervisorOption {
 	return func(sv *Supervisor) { sv.substrate = s }
+}
+
+// WithCompletionRegistry wires a CompletionRegistry into the supervisor.
+// When set, completeAgent signals the registry before clearing the task,
+// allowing BlockingSubmitter callers to unblock when a task finishes.
+func WithCompletionRegistry(r *CompletionRegistry) SupervisorOption {
+	return func(sv *Supervisor) { sv.completionRegistry = r }
 }
 
 // NewSupervisor returns a Supervisor wired to the given machine, store, and policy.
@@ -522,6 +530,14 @@ func (sv *Supervisor) completeAgent(ctx context.Context, agentID string) error {
 	}
 
 	sv.policy.RecordSuccess(agentID)
+
+	// Signal task completion BEFORE clearing CurrentTaskID so the task ID is
+	// still readable. BlockingSubmitter callers unblock here.
+	if sv.completionRegistry != nil {
+		if fields, fErr := sv.store.GetAgentFields(ctx, agentID); fErr == nil && fields.CurrentTaskID != "" {
+			sv.completionRegistry.Complete(fields.CurrentTaskID)
+		}
+	}
 
 	// Clear the assigned task so crashAgent doesn't re-enqueue a completed task.
 	// Uses ClearCurrentTask (conditional write that returns ErrAgentNotFound for


### PR DESCRIPTION
## Summary

- **CompletionRegistry** (`internal/supervisor/completion.go`): channel-based waiter map with idempotent `Complete()` (pre-closes channel for tasks completed before `Wait` is called) and `Cleanup()` to prevent memory leaks
- **BlockingSubmitter** (`internal/dag/blockingsubmitter.go`): implements `TaskSubmitter` by enqueuing then blocking on the registry until the supervisor signals completion or ctx is cancelled; replaces `StoreSubmitter` in `main.go`
- **Supervisor** wired: `WithCompletionRegistry` option; `completeAgent` signals registry **before** `ClearCurrentTask` so the task ID is still readable at signal time
- **StoreSubmitter** marked deprecated in favour of `BlockingSubmitter`

Closes #72

## Test plan

- [ ] `go vet ./...` — passes
- [ ] `go test ./internal/supervisor/... ./internal/dag/... -count=1` — all pass
- [ ] `TestCompletionRegistry_CompleteBeforeWait` — complete before wait returns immediately
- [ ] `TestCompletionRegistry_WaitThenComplete` — goroutine blocks, Complete unblocks it
- [ ] `TestCompletionRegistry_ContextCancelled` — cancelled ctx returns `context.Canceled`
- [ ] `TestCompletionRegistry_DoubleComplete` — no panic on double Complete
- [ ] `TestCompletionRegistry_Cleanup` — fresh channel after Cleanup
- [ ] `TestBlockingSubmitter_BlocksUntilComplete` — blocks, unblocks on Complete, returns nil
- [ ] `TestBlockingSubmitter_EnqueueError` — returns error immediately without calling Wait
- [ ] `TestBlockingSubmitter_ContextCancelled` — returns context error