### PR TITLE
docs: refresh README, CLAUDE.md, AGENTS.md and add architecture reference

### DIFF
--- a/.claude/handoffs/progress.txt
+++ b/.claude/handoffs/progress.txt
@@ -288,3 +288,25 @@
 - Branch: main at 8322290 (PR #164 merged as e361829, v26.3.1.0)
 
 ---
+
+## 2026-08-04 Handoff
+
+### Decisions
+- Shader pulses pinned to 0.6 (the MEAN of the old sin pulse), not 1.0 — pinning to peak left everything 67% brighter.
+- Panel size stored as viewport fractions, not pixels, so it survives resolution/monitor changes.
+- max_scroll_panels == 1 keeps the bare shared panel id, so the original singleton path runs unchanged.
+- Reaper conservative both ways: failed ListSessions aborts the sweep; agents younger than one interval are skipped.
+- Folder picker uses the in-engine FileDialog — a native portal dialog cannot be themed.
+
+### Failed Approaches
+- Blamed shaders for "random dark/light"; real cause was Hyprland decoration:dim_inactive. Fixed with a no_dim windowrule.
+- Assumed the workdir feature broke; bin/orchestrator was stale because run.sh only rebuilt when the binary was missing.
+- Nearly "fixed" a phantom infinite recursion — a sed range-print stitched two functions together. Read the real file.
+- My own smoke test clobbered the user's real settings; SigilConfig now remembers config_path and open_page uses set_value_no_signal.
+
+### Handoff Target
+- Plan file: 2026-08-04-20h35-epic-169-merged-polish-next.md (Current State + Next Steps refreshed 20h44)
+- Branch: main @ ac46ff6 — epic merged as 5211248, CI bumped 26.3.1.1 -> 26.4.0.0; app stopped, agent sessions cleaned
+- Note: progress.txt is TRACKED while .claude/ is gitignored, so edits here block branch switches (stash across checkout)
+
+---

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,63 +1,286 @@
 # AGENTS.md
 
+Operating brief for any coding agent working in this repository. Everything below
+describes what is actually built and running, not what the specs propose.
+
 ## Overview
 
-agenKic-orKistrator is a pixel-art AI office orchestrator: a native desktop app where AI agents appear as workers at desks, expose real-time activity, and can be routed across multiple model providers.
+OrKi (`agenKic-orKistrator`) is a working two-process desktop application:
 
-This repository is currently in the research and spike phase. There is no application code yet. Architectural decisions live in `docs/research/`, especially `docs/research/Agentic-Orchestrator-MOC.md`.
+- a **Go orchestrator** (`cmd/orchestrator`) that supervises agents, runs a task DAG,
+  and drives tmux sessions
+- a **Godot 4 pixel-art client** (`godot/`) that renders those agents as characters on
+  the floors of a fisheye-projected tower
 
-## Stack
+The user summons an agent from the UI; it appears on a floor and starts working.
+Floor 0 is reserved and never accepts a spawn. Exactly five spawn kinds exist:
 
-- Godot 4 with `godot-xterm` for the desktop UI
-- Go with gRPC for orchestration and IPC
-- Redis Streams and Hashes for durable state
-- tmux or WezTerm Lua for terminal/pane control
-- LiteLLM with a judge-router pattern for multi-model routing
+| Kind | What it is |
+|------|-----------|
+| `sim` | In-process fake worker (`internal/simagent`) — no external binary |
+| `claude` | Real `claude` CLI |
+| `codex` | Real `codex` CLI |
+| `opencode` | Real `opencode` CLI |
+| `pi` | Real `pi` CLI |
+
+The four CLI kinds launch the real binary inside a tmux session named `agent-<id>`,
+type the task prompt into that pane, and poll captured output until two identical
+snapshots indicate the CLI has settled (`internal/cliagent/cliagent.go`).
+
+Gemini, OpenAI, Ollama and DeepSeek appear only as cosmetic glyph/colour entries in
+Godot scripts and the reassign submenu. They are **not** spawnable.
+
+UI surfaces: Grimoire spawn flyout (F3), Power flyout (F4), Panels flyout (F5), quest
+board (task and small-DAG submission), spell scroll (parchment output view), terminal
+view, minimap, hex compass, floor tabs, and a right-click agent context menu.
+
+## Stack as built
+
+| Layer | Technology | Status |
+|-------|-----------|--------|
+| Desktop UI | Godot 4, GDScript (`godot/`) | Built |
+| UI transport | HTTP + Server-Sent Events on `127.0.0.1:8081` (`internal/httpbridge`) | Built |
+| Agent transport | gRPC on `:50051` (`proto/orchestrator.proto`, `internal/ipc`) | Built |
+| Supervision | Supervisor with heartbeats, crash recovery, exponential backoff + circuit breaker | Built |
+| Task orchestration | DAG with cycle detection, Kahn topological levels, fail-fast executor | Built |
+| Terminal substrate | tmux only (`internal/terminal`) | Built |
+| State | In-memory `state.MockStore` | Built and wired |
+| State (durable) | `state.RedisStore` (`internal/state/redis.go`) | Built, **not wired** — zero non-test call sites |
+| Model gateway | LiteLLM client + Judge-Router (`internal/gateway`) | Built and tested, **not wired** — no `cmd/` binary imports it |
+| Live PTY terminal | `godot-xterm` addon | **Not committed** — install separately (see Platform support) |
+| WezTerm substrate | — | **Not built.** No WezTerm code exists anywhere |
+| TUI (Bubbletea/Lip Gloss) | — | **Not built** |
+
+The running binary therefore makes **no LLM completion calls** and does **no cost-based
+model routing**. All model work happens inside the external CLI agents.
 
 ## Commands
 
-No build, run, or test commands exist yet. Update this file once the Go module and Godot project are scaffolded.
+Go toolchain is `go 1.26.1` (`go.mod`). Any README badge claiming an older minimum is stale.
+
+```bash
+./setup.sh                      # one-time: toolchain, godot-xterm addon, protoc gen, build, start Redis
+./run.sh                        # build if stale, start orchestrator, wait for the bridge, launch Godot
+
+make generate                   # protoc -> gen/pb/orchestrator (needs protoc + Go plugins on PATH)
+make build                      # bin/orchestrator from ./cmd/orchestrator
+make test                       # go test -race -count=1 ./internal/...
+make test-integration           # same, with -tags=integration (needs Redis)
+make lint                       # golangci-lint run ./...
+make clean                      # rm -rf bin/ gen/pb/
+go vet ./...
+
+# Third test tier, build-tagged `testenv`. Nothing committed runs it — no Makefile
+# target and no CI step. Run it manually:
+go test -tags=testenv ./internal/... ./e2e/...
+
+# Godot tests are standalone headless scripts (no GUT vendored), run one at a time:
+godot --headless --path godot --script tests/<name>.gd
+```
+
+Do **not** start the orchestrator or Godot without being asked — the user may already
+have the app running.
+
+### Environment variables and default ports
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `GRPC_ADDR` | `:50051` | gRPC control plane (agents dial this) |
+| `BRIDGE_ADDR` | `127.0.0.1:8081` | HTTP + SSE bridge (the Godot UI talks to this) |
+| `HEALTH_ADDR` | `:8080` | HTTP health server |
+| `BRIDGE_API_KEY` | unset | When set, all bridge endpoints require `Authorization: Bearer <key>`. When unset the orchestrator logs a warning and serves unauthenticated |
+| `MIN_AGENT_COUNT` | `1` | Minimum agent count used by the health aggregator |
+| `REDIS_URL` | — | Read by integration tests only, not by the orchestrator |
 
 ## Architecture
 
-Planned architecture:
+### Two servers, two transports
 
-- `cmd/orchestrator/main.go`: supervisor entrypoint
-- `internal/supervisor/`: restart strategies, health probes, supervision tree
-- `internal/agent/`: agent lifecycle and state machine
-- `internal/dag/`: task DAG execution
-- `internal/ipc/`: gRPC services and transport
-- `internal/state/`: Redis-backed state and event storage
-- `internal/gateway/`: LiteLLM gateway, routing, provider adapters
-- `internal/terminal/`: tmux / WezTerm substrate
-- `proto/orchestrator.proto`: API contract
-- `godot/`: Godot desktop client
+`cmd/orchestrator/main.go` starts both:
 
-Key decisions from the research MOC:
+1. **gRPC on `:50051`** — the agent-to-orchestrator control plane only. Defined in
+   `proto/orchestrator.proto`, served by `internal/ipc`. Dialled by `internal/cliagent`
+   and `internal/simagent` (sim agents loop back to the orchestrator's own address so
+   they exercise the identical API).
+2. **HTTP + SSE on `127.0.0.1:8081`** — `internal/httpbridge`. This, not gRPC, is the
+   Godot-facing transport.
 
-- Supervisor/worker plus DAG orchestration
-- gRPC for typed IPC, Redis for durable coordination
-- "Context window = RAM"; persistent state externalized
-- OTP-style supervision over defensive long-lived processes
-- Godot 4 plus `godot-xterm` for the pixel-office UI
-- tmux as the primary terminal substrate
+A separate HTTP health server runs on `:8080`.
 
-## Active Work
+### Bridge routes (`internal/httpbridge/bridge.go`)
 
-Current work is research-driven:
+```
+GET  /api/agents
+GET  /api/agents/{id}/output
+GET  /api/floors
+GET  /api/providers
+POST /api/tasks
+POST /api/dags
+POST /api/agents/{id}/input
+POST /api/agents/{id}/cancel
+POST /api/agents/{id}/reassign
+POST /api/agents/{id}/despawn
+POST /api/agents/spawn
+POST /api/admin/restart
+GET  /events/stream          (SSE)
+```
 
-- Validate Godot 4 plus `godot-xterm` as the desktop UI path
-- Prototype tmux-based multi-agent orchestration with shared Redis state
-- Design the agent state machine and routing algorithm
-- Evaluate Anthropic Agent SDK fit for structured agent-to-agent calls
+### Packages
 
-## Git Workflow
+`cmd/`:
 
-All work is issue-driven. Never push directly to `main`.
+| Binary | Purpose |
+|--------|---------|
+| `orchestrator` | The supervisor process — gRPC + HTTP/SSE bridge + health |
+| `demoworker` | Standalone demo gRPC worker |
+| `spritegen` | Asset development tool |
+| `assetslice` | Asset development tool |
 
-- Create an issue first, then work from the generated issue branch
-- Branch types: `epic/*`, `feature/*`, `task/*`, `bug/*`, `hotfix/*`
-- All PRs are squash-merged
+`internal/` — 11 packages plus `internal/gateway/providers`:
+
+| Package | Purpose |
+|---------|---------|
+| `agent` | Agent state machine and transitions |
+| `cliagent` | Spawns and drives real CLI binaries (claude/codex/opencode/pi) |
+| `dag` | Graph + cycle detection, topological levels, executor, status tracker |
+| `gateway` | LiteLLM client and Judge-Router (unwired — see gotchas) |
+| `gateway/providers` | Per-provider request/response adapters (anthropic, openai, ollama) |
+| `health` | Health aggregator feeding both the gRPC and HTTP health surfaces |
+| `httpbridge` | HTTP + SSE bridge for the Godot UI |
+| `ipc` | gRPC server, handlers, health HTTP server |
+| `simagent` | In-process simulated worker |
+| `state` | `StateStore` interface, `MockStore` (wired), `RedisStore` (unwired) |
+| `supervisor` | Registration, heartbeat staleness, crash recovery, restart policy, reapers |
+| `terminal` | `Substrate` interface with a single tmux implementation |
+
+### Supervisor, DAG, terminal
+
+- **Supervisor** (`internal/supervisor/supervisor.go`): registration, heartbeat
+  staleness detection, `crashAgent` recovery, per-agent mutexes, task-assign loop.
+- **Restart policy** (`restart.go`): exponential backoff, base 1s / max 30s, with a
+  sliding-window circuit breaker (window 60s, threshold 5 crashes).
+- **Reapers**: a tombstone reaper in `completion.go`; a separate orphan-tmux-session
+  reaper on a 15s interval in `reaper.go`.
+- **DAG**: `graph.go` (build + cycle detection), `sort.go` (Kahn levels), `executor.go`
+  (level-by-level, fail-fast), `status.go` (tracker). `main.go` wires
+  `dag.NewBlockingSubmitter`, which blocks on the shared `CompletionRegistry`.
+- **Terminal**: `terminal.Substrate` has exactly one implementation, `TmuxSubstrate`,
+  which shells out via `exec.LookPath("tmux")`.
+
+### Protobuf regeneration
+
+`proto/orchestrator.proto` is the contract. `make generate` writes into `gen/pb/orchestrator`.
+`gen/` is gitignored — generated code is never committed, so a fresh clone must run
+`make generate` (or `./setup.sh`) before anything compiles.
+
+## Constraints and gotchas
+
+1. **State is in-memory only.** `main.go` constructs `state.NewMockStore()` and nothing
+   else. All state is lost on restart. `RedisStore` is complete (~500 lines) but has no
+   non-test caller.
+2. **Redis is not used by the orchestrator.** `setup.sh`, `docker-compose.yml` and CI all
+   start a `redis:7-alpine` container, and `go-redis` is a direct dependency, but the
+   shipped binary never connects. Redis is needed for `make test-integration`, nothing else.
+3. **`internal/health` reports `RedisPingOK`** — that field pings whatever store is wired,
+   which today is the MockStore. It is not evidence of a Redis connection.
+4. **`internal/gateway` is dead code from the running binary's perspective.** Do not
+   describe judge-routing or cost tracking as live behaviour. `config/models.yaml` is
+   likewise only read by gateway code.
+5. **`supervisor.ShutdownHandler` has zero callers.** `main.go` implements its own signal
+   handling in `gracefulShutdown`. Editing `ShutdownHandler` changes nothing at runtime.
+6. **Adding a spawn kind touches three places**: the `switch req.Kind` validation in
+   `handleSpawnAgent`, the `providerRoster` slice in `internal/httpbridge/handlers.go`,
+   and the `cliCommands` / `interactiveCommands` / `cliBinaries` maps in
+   `internal/cliagent/cliagent.go`. Missing any one produces a half-registered kind.
+7. **Task priority is min-first.** The queue dequeues the *lowest* priority number first
+   (`MockStore` sorts ascending; `RedisStore` uses `ZPopMin`). A "high priority" task is a
+   low number.
+8. **Floor 0 is reserved.** An explicit `floor: 0` spawn is rejected with 400; an omitted
+   floor auto-picks the lowest non-full floor >= 1.
+9. **Cancel bypasses the agent state machine.** The bridge holds no `Supervisor` or
+   `agent.Machine`, so `/cancel` acts directly on the store: best-effort Ctrl-C to the
+   PTY, then `ClearCurrentTask`, then a compare-and-set to idle. A cancelled DAG node is
+   observed by the executor as *completed with no output*, not as failed.
+10. **Reassign is an inert hint.** `/reassign` persists `TaskMeta.Provider`, but the
+    supervisor's assign loop never reads it. It is requeue-with-a-hint, not live migration.
+11. **`make generate` needs the protoc Go plugins on PATH.** `protoc-gen-go` and
+    `protoc-gen-go-grpc` usually live in `~/go/bin`, which many shells omit. `run.sh`
+    prepends it explicitly.
+12. **`gen/` is gitignored.** Never commit generated protobuf output; never assume it
+    exists in a clean checkout.
+
+## Platform support
+
+- **Linux and macOS**: full experience. tmux drives live agent sessions; `/output` and
+  `/input` work; the terminal view shows a live PTY.
+- **Windows or any host without tmux**: `main.go` logs
+  `terminal substrate unavailable, running headless` and continues. `cliagent` then falls
+  back to one-shot process execution (`claude -p …`, `codex exec …`, `opencode run …`,
+  `pi -p …`) with output streamed back over gRPC. `GET /api/agents/{id}/output` and
+  `POST /api/agents/{id}/input` both return **501 Not Implemented**.
+- **`godot-xterm` is not committed.** The live PTY terminal requires installing it via
+  `godot/addons/install_godot_xterm.sh` (documented in [godot/addons/VENDOR.md](godot/addons/VENDOR.md));
+  `setup.sh` does this automatically. Its PTY support is Linux/macOS only.
+
+## Active work and known gaps
+
+Honest gap list, roughly in priority order:
+
+- Wire `state.RedisStore` into `cmd/orchestrator` so state survives a restart, or delete it.
+- Wire `internal/gateway` into something, or mark it explicitly experimental.
+- Wire `supervisor.ShutdownHandler` into the shutdown path, or remove it in favour of
+  `gracefulShutdown`.
+- Put the `testenv` suite (`internal/...` + `e2e/...`) into a Makefile target and CI.
+- Put the Godot headless test scripts under `godot/tests/` into CI.
+- Correct the versioning section in [.github/CI-CD-Guide.md](.github/CI-CD-Guide.md) and the
+  README — both still describe a stale `YY.MM.Major.Minor` scheme.
+- Fix the README's spec links: the four headline specs live under `specs/`, not repo root.
+
+## Git workflow
+
+All work is issue-driven. **Never push directly to `main`.**
+
+1. Create an issue and label it. `issue-branch-handler.yml` auto-creates a branch and a
+   draft PR. Label priority when several are present: `epic` > `feature` > `task` > `bug` > `hotfix`.
+2. Sub-issues branch from their parent's branch.
+3. All PRs are squash-merged.
+
+| Label | Branch | PR title prefix |
+|-------|--------|-----------------|
+| `epic` | `epic/{n}-kebab-title` | `epic:` |
+| `feature` | `feature/{n}-kebab-title` | `feat:` |
+| `task` | `task/{n}-kebab-title` | `chore:` |
+| `bug` | `bug/{n}-kebab-title` | `fix:` |
+| `hotfix` | `hotfix/{n}-kebab-title` | `hotfix:` |
+
+### Versioning — `YY.Major.Minor.Patch[Suffix]`
+
+Validated against `^([0-9]{2})\.([0-9]+)\.([0-9]+)\.([0-9]+)([a-zA-Z]*)$`. Current `VERSION`
+is `26.4.0.0`.
+
+| Merged branch | Effect |
+|---------------|--------|
+| `epic/*` | Major +1, Minor -> 0, Patch -> 0, suffix cleared |
+| `feature/*` | Minor +1, Patch -> 0, suffix cleared |
+| `task/*`, `bug/*` | Patch +1, suffix cleared |
+| `hotfix/*` | Append/increment suffix letter (a, b … z, aa …) |
+
+Bumps fire only on **merged** PRs targeting `main` or `epic/**`. Year rollover is automatic:
+if the stored `YY` differs from the current year, the version resets to `YY.0.0.0`.
+
+### Reference documents
+
+- [specs/go-orchestrator-core-spec.md](specs/go-orchestrator-core-spec.md)
+- [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) — how the system actually fits together
+- [specs/terminal-substrate-spec.md](specs/terminal-substrate-spec.md)
+- [specs/model-gateway-spec.md](specs/model-gateway-spec.md)
+- [specs/pixel-office-ui-spec.md](specs/pixel-office-ui-spec.md)
+- [godot/PORTING.md](godot/PORTING.md), [godot/PARITY.md](godot/PARITY.md)
+- [.github/CI-CD-Guide.md](.github/CI-CD-Guide.md)
+- [docs/research/Agentic-Orchestrator-MOC.md](docs/research/Agentic-Orchestrator-MOC.md) — pre-build research; historical, not a description of the current system
+
+Specs describe intent. Where a spec and the code disagree, the code wins — check before
+treating a spec feature as built.
 
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,23 +4,164 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## What This Is
 
-**agenKic-ochKistrator** — a pixelated AI office orchestrator. A native desktop application where AI agents appear as pixel-art workers at desks. Users see agent activity in real time, route tasks across models (Claude, Gemini, Ollama), and coordinate multi-agent workflows from a retro-aesthetic interface.
+**OrKi / agenKic-orKistrator** — a pixelated AI office orchestrator. Agents are summoned from a Godot 4 pixel-art UI and appear as characters on the floors of a fisheye-projected tower. Users watch agent activity live, submit tasks and small DAGs, and drive real CLI coding agents from a retro-aesthetic interface.
 
-This repo is currently in the **research and spike phase**. No application code exists yet — the codebase will be built out from the decisions documented in `docs/research/`.
+This is a **working two-process desktop app**, not a research repo: a Go orchestrator (`cmd/orchestrator`) plus a Godot 4 client (`godot/`), launched together by `./run.sh`. Roughly 120 `.go` files (53 `_test.go`) and 82 `.gd` files. `VERSION` is `26.4.0.0`.
 
-## Planned Stack
+### What actually runs
 
-| Layer | Technology | Notes |
-|-------|-----------|-------|
-| Desktop UI | Godot 4 + godot-xterm | Pixel-art office; PTY is Linux/macOS only — Windows gets display-only |
-| Orchestrator | Go + gRPC | Supervisor/worker + LangGraph-style DAG |
-| IPC | gRPC agent-to-agent + Redis Streams | Type-safe, durable, backpressure |
-| State | Redis (Streams + Hashes) | Context window = RAM; all persistent state externalized |
-| Terminal substrate | tmux or WezTerm Lua | Programmatic pane control per agent |
-| TUI (alt) | Bubbletea + Lip Gloss (Go) | Elm architecture, no render/state divergence |
-| Model gateway | LiteLLM + Judge-Router | Haiku judges → Sonnet works → Opus architects; 60–90% cost savings |
+- The Godot client talks to the orchestrator over **HTTP + SSE on `127.0.0.1:8081`** (`internal/httpbridge`). Agents talk to the orchestrator over **gRPC on `:50051`** (`internal/ipc`). These are two separate planes — do not conflate them.
+- Spawnable agent kinds are exactly five: `sim`, `claude`, `codex`, `opencode`, `pi` (`internal/httpbridge/handlers.go:719-729`). `sim` is an in-process fake worker (`internal/simagent`); the other four exec the real CLI binary inside a tmux session named `agent-<id>`, type the prompt into the pane, and poll `CaptureOutput` until two identical snapshots mean the CLI settled (`internal/cliagent/cliagent.go:117-279`).
+- Gemini, OpenAI, Ollama and DeepSeek appear **only** as cosmetic glyph/colour dictionaries in Godot scripts and in the Reassign submenu (`godot/scripts/panels/terminal_view.gd:32-39`, `godot/scripts/overlays/agent_context_menu.gd:27`). They are not spawnable.
+- UI surfaces: Grimoire spawn flyout (F3), Power flyout (F4), Panels flyout (F5), quest board (task + small DAG submission), spell scroll (parchment output view), terminal view, minimap, hex compass, floor tabs, right-click agent context menu.
 
-Read `docs/research/Agentic-Orchestrator-MOC.md` for the full architectural decision table and competitive landscape rationale before touching any design.
+## Real Stack (as built)
+
+| Layer | Technology | Status |
+|-------|-----------|--------|
+| Desktop UI | Godot 4 project in `godot/` | **built** |
+| Terminal widget | godot-xterm | **not committed** — install via `godot/addons/install_godot_xterm.sh`, see [godot/addons/VENDOR.md](godot/addons/VENDOR.md); PTY is Linux/macOS only |
+| Orchestrator | Go 1.26.1, `cmd/orchestrator` | **built** |
+| Agent ↔ orchestrator transport | gRPC on `:50051` (`GRPC_ADDR`), `proto/orchestrator.proto` + `internal/ipc` | **built** |
+| Godot ↔ orchestrator transport | HTTP + SSE on `127.0.0.1:8081` (`BRIDGE_ADDR`), `internal/httpbridge` | **built** |
+| Health endpoint | HTTP on `:8080` (`HEALTH_ADDR`), `internal/health` | **built** |
+| State | `state.NewMockStore()` — in-memory only (`cmd/orchestrator/main.go:47`) | **built** |
+| Redis store | `internal/state/redis.go` (~503 lines, fully tested) | **built but unwired** — zero non-test call sites |
+| Terminal substrate | tmux only (`internal/terminal/tmux.go`), via `exec.LookPath("tmux")` | **built** |
+| WezTerm substrate | — | **not built** — no WezTerm code exists anywhere in the repo |
+| Model gateway | `internal/gateway`: LiteLLM client + JudgeRouter + provider adapters, `config/models.yaml` | **built but unwired** — imported by no `cmd/` binary; the running orchestrator makes no LLM completion calls |
+| Supervisor / DAG | `internal/supervisor`, `internal/dag` | **built** |
+
+Bridge auth is opt-in: with `BRIDGE_API_KEY` set the bridge requires a bearer token; unset, it logs a warning and runs unauthenticated (`cmd/orchestrator/main.go:131-136`, `internal/httpbridge/bridge.go:94-96`).
+
+### HTTP bridge routes
+
+`internal/httpbridge/bridge.go:178-192`:
+
+```
+GET  /api/agents
+GET  /api/agents/{id}/output
+GET  /api/floors
+GET  /api/providers
+POST /api/tasks
+POST /api/dags
+POST /api/agents/{id}/input
+POST /api/agents/{id}/cancel
+POST /api/agents/{id}/reassign
+POST /api/agents/{id}/despawn
+POST /api/agents/spawn
+POST /api/admin/restart
+GET  /events/stream          # SSE
+```
+
+## Build, Run, Test
+
+```bash
+./setup.sh                 # toolchain + deps; also starts a redis:7-alpine container
+make generate              # protoc -> gen/pb/orchestrator (needs $(go env GOPATH)/bin on PATH)
+make build                 # bin/orchestrator from ./cmd/orchestrator
+make test                  # go test -race -count=1 ./internal/...
+make test-integration      # same, -tags=integration (needs REDIS_URL)
+make lint                  # golangci-lint run ./...
+make clean                 # rm -rf bin/ gen/pb/
+go vet ./...               # CI runs this between generate and test
+```
+
+`./run.sh` is the normal entrypoint: it rebuilds only when a `.go` source or `go.mod` is newer than `bin/orchestrator`, starts the orchestrator, polls the bridge address for up to 10s, then launches `godot --path godot`. Ctrl-C kills Godot and sends SIGTERM to the orchestrator for the graceful shutdown path.
+
+**Third test tier — not automated.** Files tagged `//go:build testenv` live in `internal/dag`, `internal/supervisor` and `e2e/`. No Makefile target and no CI step runs them. Manual invocation:
+
+```bash
+go test -tags=testenv ./internal/... ./e2e/...
+```
+
+**Godot tests** are standalone headless GDScript files under `godot/tests/` (29 files). No GUT or other Godot test runner is vendored:
+
+```bash
+godot --headless --path godot --script tests/wander_math_test.gd
+```
+
+### Environment variables
+
+| Var | Default | Effect |
+|-----|---------|--------|
+| `GRPC_ADDR` | `:50051` | gRPC listen address (agents) |
+| `BRIDGE_ADDR` | `127.0.0.1:8081` | HTTP+SSE bridge listen address (Godot) |
+| `HEALTH_ADDR` | `:8080` | health HTTP listen address |
+| `BRIDGE_API_KEY` | unset | when set, bridge requires bearer auth; unset = no auth |
+| `MIN_AGENT_COUNT` | `1` | health aggregator minimum-agents threshold |
+| `REDIS_URL` | unset | consumed only by `make test-integration` |
+
+## Load-bearing constraints an agent must know
+
+1. **State is in-memory.** `cmd/orchestrator/main.go:47` hardcodes `state.NewMockStore()`. `internal/state/redis.go` is complete and tested but has zero non-test call sites — any Redis work is dead code until someone wires the constructor into `main.go`. `internal/health` reports a field named `RedisPingOK` that in practice pings the MockStore.
+2. **Redis is still started around the build.** `setup.sh`, `docker-compose.yml` and CI all start `redis:7-alpine`, and `make test-integration` needs it. The orchestrator binary itself never connects to it.
+3. **`internal/gateway` is not in the running system.** `grep 'gateway\.' cmd/` returns nothing. The JudgeRouter (Haiku classifies into cheap/mid/frontier) and the LiteLLM client (default `http://localhost:8000/chat/completions`) are exercised only by their own tests. No cost-based routing happens at runtime.
+4. **`supervisor.ShutdownHandler` has zero production callers.** `cmd/orchestrator/main.go:189-234` does its own signal handling and calls `gracefulShutdown` directly. Don't assume the handler is on the shutdown path.
+5. **Adding a spawn kind touches three places**: `providerRoster` (`internal/httpbridge/handlers.go:674-697`), the kind switch (`:719-729`), and `cliBinaries` (`internal/cliagent/cliagent.go:79-84`). Miss one and the kind is either invisible, rejected, or unlaunchable.
+6. **The Godot UI reads `/api/providers`**, so a new adapter added to `providerRoster` appears in the Grimoire flyout with no GUI change.
+7. **Proto changes require `make generate`** with `$(go env GOPATH)/bin` on PATH (that's where `protoc-gen-go` and `protoc-gen-go-grpc` land). `gen/` is generated and gitignored — never commit it, never hand-edit it.
+8. **Quest-board priority is a min-heap** (`DequeueTask` == `ZPOPMIN`). "High" maps to a LOW number: `PRIORITY_HIGH = 1.0`, `NORMAL = 5.0`, `LOW = 10.0` (`godot/scripts/panels/quest_board_view.gd:14-23`). Inverting this makes high-priority quests run last.
+9. **Floor 0 is reserved** and never accepts a spawn — the bridge rejects it with 400 (`internal/httpbridge/handlers.go:760-796`). Omitting a floor makes the bridge pick the lowest non-full floor ≥ 1.
+10. **Task cancel bypasses the agent state machine** (`internal/httpbridge/handlers.go:297-401`). Read that path before changing agent state transitions.
+11. **Reassign is a hint, not a migration.** It persists `TaskMeta.Provider` and re-enqueues at the original priority, but the supervisor assign loop never reads that field (`internal/httpbridge/handlers.go:403-539`). It is requeue-with-a-hint.
+12. **No tmux = degraded mode.** If `tmux` is absent, `main.go:55-60` logs `terminal substrate unavailable, running headless`; `cliagent` falls back to one-shot exec (`claude -p …`, `codex exec …`, `opencode run …`, `pi -p …`) and `/output` and `/input` return 501.
+
+## Real Module Map
+
+```
+cmd/orchestrator/       # the supervisor binary — gRPC + bridge + health servers
+cmd/demoworker/         # demo gRPC worker agent
+cmd/spritegen/          # asset dev tool: sprite generation
+cmd/assetslice/         # asset dev tool: spritesheet slicing
+
+internal/agent/         # agent state machine, worker lifecycle
+internal/cliagent/      # spawns real CLI agents (claude/codex/opencode/pi) into tmux panes
+internal/dag/           # graph + cycle detection, Kahn levels, level-by-level executor, StatusTracker
+internal/gateway/       # LiteLLM client + JudgeRouter (unwired)
+internal/gateway/providers/  # per-provider request/response adapters
+internal/health/        # health aggregator behind the :8080 HTTP endpoint and gRPC health service
+internal/httpbridge/    # HTTP + SSE bridge — the Godot-facing transport
+internal/ipc/           # gRPC server, handlers, health HTTP server
+internal/simagent/      # in-process simulated worker ("sim" kind)
+internal/state/         # Store interface, MockStore (used), RedisStore (unwired)
+internal/supervisor/    # registration, heartbeats, crash recovery, restart policy, reapers
+internal/terminal/      # Substrate interface + the single tmux implementation
+
+proto/orchestrator.proto  # gRPC service + message definitions
+config/models.yaml        # gateway tier definitions and fallback chains (unwired)
+e2e/                      # testenv-tagged end-to-end tests, not run by CI
+gen/                      # generated protobuf — gitignored
+
+godot/scripts/    # GDScript: tower, panels, overlays, agent characters, bridge client
+godot/scenes/     # .tscn scene files
+godot/assets/     # sprites, spritesheets, fonts
+godot/shaders/    # fisheye projection and visual effects
+godot/themes/     # UI themes
+godot/config/     # client-side config resources
+godot/tests/      # standalone headless GDScript tests (no runner vendored)
+godot/addons/     # godot-xterm install script + VENDOR.md; the addon itself is not committed
+```
+
+Behavioural notes worth knowing before touching these:
+
+- **Supervisor** (`internal/supervisor/supervisor.go`, ~769 lines): registration, heartbeat staleness detection, `crashAgent` recovery, per-agent mutexes, task-assign loop. Restart policy is exponential backoff (base 1s, max 30s) with a sliding-window circuit breaker (60s window, 5 crashes) — `internal/supervisor/restart.go:54-144`. A tombstone reaper lives in `completion.go` and a separate orphan-tmux-session reaper (15s) in `reaper.go`.
+- **DAG**: `main.go:73-74` wires `BlockingSubmitter` (blocks on `CompletionRegistry.Wait`), not the deprecated `StoreSubmitter`. The executor runs level-by-level with fail-fast.
+
+## Feature Specs
+
+The four headline implementation blueprints live in **`specs/`**, not at repo root. Each carries must-have/should-have scope, API contracts, Gherkin acceptance scenarios, task breakdowns, and exit criteria.
+
+| Spec file | Component |
+|-----------|-----------|
+| [specs/go-orchestrator-core-spec.md](specs/go-orchestrator-core-spec.md) | Supervisor process, agent state machine, DAG engine |
+| [specs/terminal-substrate-spec.md](specs/terminal-substrate-spec.md) | tmux session management, command injection, output capture |
+| [specs/model-gateway-spec.md](specs/model-gateway-spec.md) | LiteLLM proxy, Judge-Router, provider adapters, cost tracking (built, unwired) |
+| [specs/pixel-office-ui-spec.md](specs/pixel-office-ui-spec.md) | Godot 4 pixel-art office, godot-xterm, agent sprites, panel layout |
+
+`specs/` holds 16 spec files in total; `docs/specs/todo/` holds 6 more not yet started. The loose `.md` files at repo root (council reports and older specs) are historical and out of scope — treat `specs/` as current.
+
+Godot-side design docs: [godot/PORTING.md](godot/PORTING.md), [godot/PARITY.md](godot/PARITY.md).
 
 ## Git Workflow
 
@@ -58,55 +199,60 @@ hotfix/{n}-kebab-title
 
 All PRs are squash-merged.
 
-## Feature Specs
+Version bumps fire only on **merged** PRs into `main` or `epic/**`. The version regex is
+`^([0-9]{2})\.([0-9]+)\.([0-9]+)\.([0-9]+)([a-zA-Z]*)$` (`version-bump.yml:69-80`,
+`version-validation.yml:32-36`). Year rollover is handled automatically inside
+`version-bump.yml:82-87` — the manual `year-rollover` dispatch is a fallback, not the
+normal path.
 
-Four feature spec files live at repo root — these are the implementation blueprints, each with must-have/should-have scope, gRPC API contracts, acceptance scenarios (Gherkin), task breakdowns, and exit criteria:
-
-| Spec file | Component | Key dependencies |
-|-----------|-----------|-----------------|
-| `go-orchestrator-core-spec.md` | Supervisor process, agent state machine, DAG engine | Redis, gRPC |
-| `terminal-substrate-spec.md` | tmux session management, command injection, output capture | tmux binary, `os/exec` |
-| `model-gateway-spec.md` | LiteLLM proxy, Judge-Router, provider adapters, cost tracking | LiteLLM sidecar |
-| `pixel-office-ui-spec.md` | Godot 4 pixel-art office, godot-xterm, agent sprites, panel layout | Orchestrator gRPC API |
-
-## Planned Go Module Layout
-
-From the specs (no code written yet):
-
-```
-cmd/orchestrator/main.go          # supervisor entrypoint
-internal/supervisor/              # supervision tree, restart strategies, health probes
-internal/agent/                   # agent state machine, worker lifecycle
-internal/dag/                     # task DAG engine, topological execution
-internal/ipc/                     # gRPC server + service definitions
-internal/state/                   # Redis client (Streams, Hashes, Sorted Sets)
-internal/gateway/                 # Gateway interface, judge-router, LiteLLM client
-internal/gateway/providers/       # per-provider format adapters
-internal/terminal/                # Substrate interface, tmux.go, wezterm.go
-proto/orchestrator.proto          # gRPC service + message definitions
-config/models.yaml                # tier definitions, model assignments, fallback chains
-godot/                            # Godot 4 project (separate from Go module)
-```
+> [.github/CI-CD-Guide.md](.github/CI-CD-Guide.md) and `README.md` both still describe a
+> stale `YY.MM.Major.Minor` scheme. **This file is authoritative** for versioning.
+> The README also carries a `go-1.23+` badge (`go.mod` declares `go 1.26.1`) and links the
+> four feature specs at repo root, where they no longer are.
 
 ## CI/CD
 
 Workflows in `.github/workflows/`:
+- `ci.yml` — the real build/test gate
 - `issue-branch-handler.yml` — auto-creates branch + draft PR when an issue is labelled
 - `version-bump.yml` / `version-validation.yml` — automated versioning on merge
 - `release.yml` — release packaging
 - `manual-version-bump.yml` — manual bumps and year rollover via `workflow_dispatch`
 
-No build/test commands exist yet — this section should be updated when the Go module is scaffolded.
+`ci.yml` triggers on push to `main`, `epic/**`, `feature/**` and on PRs into `main`, `epic/**`.
+It runs a `redis:7-alpine` service container, installs protoc plus the Go protoc plugins, then:
 
-## Research
+```
+make generate  →  go vet ./...  →  make test  →  make test-integration  (REDIS_URL=redis://localhost:6379)
+```
 
-`docs/research/` contains all pre-build research (2026-03-14, 11-agent parallel research team + adversarial council verification).
+Not in CI: the `testenv`-tagged suite (`internal/dag`, `internal/supervisor`, `e2e/`) and the
+headless Godot tests. Both must be run by hand.
 
-- **Start here**: `docs/research/Agentic-Orchestrator-MOC.md` — links every finding, key decisions, and next spikes
-- `docs/research/` — raw session notes (IPC, state management, process supervision, competitive landscape, terminal infra, pixel UI eval, council fact-checks)
-- `docs/research/patterns/` — refined reference versions of core patterns from Digital Garden
+## Architecture reference
 
-Key caveats from council verification (read before citing numbers):
+[docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) — process topology, the full bridge endpoint
+list, supervisor model, DAG engine, terminal substrate, Godot client structure, and a
+planned-vs-built table. Read it before making structural changes.
+
+## Research (historical)
+
+`docs/research/` holds the pre-build research (2026-03-14, 11-agent parallel research team +
+adversarial council verification). It records **intent at the time**, not the shipped system.
+
+- **Start here**: [docs/research/Agentic-Orchestrator-MOC.md](docs/research/Agentic-Orchestrator-MOC.md) — architectural decision table and competitive landscape
+- `docs/research/patterns/` — refined reference versions of core patterns
+
+**Research says X, code does Y** — check the code before citing any of these:
+
+| Research claims | The code does |
+|---|---|
+| Redis Streams + Hashes as the state layer | `main.go:47` uses `state.NewMockStore()`; `RedisStore` has zero non-test callers |
+| LiteLLM + Judge-Router routing live traffic for 60–90% savings | `internal/gateway` is imported by no `cmd/` binary; no LLM calls at runtime |
+| tmux **or** WezTerm Lua as the substrate | tmux only; there is no WezTerm code in the repo |
+| gRPC as the UI transport | gRPC is the agent plane; the Godot client uses HTTP + SSE on `127.0.0.1:8081` |
+
+Other caveats from council verification:
 - godot-xterm PTY is Linux/macOS only — Windows shows terminal display but no live shell
 - DeepSeek V3.2 $0.03/1M pricing applies to cached input only
 - Pixel Agents star count has a discrepancy (4.4k vs 2.8k) in notes — verify before citing

--- a/README.md
+++ b/README.md
@@ -1,65 +1,192 @@
 # agenKic-orKistrator
 
 ![Version](https://img.shields.io/badge/version-26.4.0.0-blue)
-![Go](https://img.shields.io/badge/go-1.23+-00ADD8?logo=go)
+![Go](https://img.shields.io/badge/go-1.26+-00ADD8?logo=go)
 ![Godot](https://img.shields.io/badge/godot-4.x-478CBF?logo=godotengine)
-![Tests](https://img.shields.io/badge/tests-none%20yet-lightgrey)
+![Tests](https://img.shields.io/badge/tests-go%20%2B%20godot%20headless-brightgreen)
 ![Build](https://img.shields.io/github/actions/workflow/status/Kiriketsuki/agenKic-orKistrator/version-bump.yml?label=ci)
 ![License](https://img.shields.io/badge/license-MIT-green)
-![Status](https://img.shields.io/badge/status-research%20%2F%20spike-orange)
+![Status](https://img.shields.io/badge/status-alpha%20%2F%20working%20vertical%20slice-yellow)
 
-A pixelated AI office orchestrator. AI agents appear as pixel-art workers at desks. Users see agent activity in real time, route tasks across models (Claude, Gemini, Ollama), and coordinate multi-agent workflows from a retro-aesthetic desktop interface.
-
-> Currently in the **research and spike phase.** No application code exists yet — all decisions are documented in [`docs/research/`](docs/research/).
+OrKi is a two-process desktop app: a Go orchestrator and a Godot 4 pixel-art client. You
+summon coding-CLI agents from the GUI; the orchestrator spawns each one inside its own
+`tmux` session, feeds it a task prompt, polls the pane until the CLI settles, and streams
+state back to the client, where every agent is drawn as a pixel character on a floor of a
+fisheye-projected tower.
 
 ---
 
-## Stack
+## What you actually see when you run it
 
-| Layer | Technology |
-|-------|-----------|
-| Desktop UI | Godot 4 + godot-xterm |
-| Orchestrator | Go + gRPC |
-| IPC | gRPC agent-to-agent + Redis Streams |
-| State | Redis (Streams + Hashes) |
-| Terminal substrate | tmux / WezTerm Lua |
-| TUI (alt) | Bubbletea + Lip Gloss |
-| Model gateway | LiteLLM + Judge-Router |
+`./run.sh` builds the orchestrator if it is stale, starts it, waits for the HTTP bridge to
+accept connections, then launches Godot. Ctrl-C tears both down.
 
-## Architecture
+- **F3 — Grimoire.** The summoning flyout. Pick a sigil, pick a floor, and an agent spawns.
+  Floor 0 is reserved and never accepts a spawn (`internal/httpbridge/handlers.go`).
+- **Spawnable kinds are exactly five:** `sim`, `claude`, `codex`, `opencode`, `pi`. `sim` is
+  an in-process fake worker used for demos and tests; the other four exec the real CLI
+  binary of that name. **Gemini, OpenAI, Ollama and DeepSeek are cosmetic only** — they
+  exist as glyph/colour entries in the Godot scripts and in the Reassign submenu, and are
+  not spawnable.
+- **The agent appears as a pixel character** on its floor and animates through its lifecycle
+  states.
+- **F5 — Panels.** Opens per-agent panels: terminal view, spell scroll (parchment output
+  view), quest board (task and small-DAG submission), plus layout presets.
+- **Right-click an agent** for View Details / Open Terminal / Open Scroll / Reassign /
+  Cancel / Copy Output / Banish.
+- **F4 — Power.** Banish all, restart orchestrator, settings, quit to title.
+- **Minimap, hex compass and floor tabs** are read-only views over the same state.
 
-Read [`docs/research/Agentic-Orchestrator-MOC.md`](docs/research/Agentic-Orchestrator-MOC.md) for the full architectural decision table, competitive landscape, and rationale before touching any design.
+Reassign persists a provider hint on the task and requeues it — the supervisor's assign
+loop does not read that field, so it is not a live migration of a running agent.
+
+## Quickstart
+
+Prerequisites:
+
+| Requirement | Notes |
+|---|---|
+| Go 1.26+ | `go.mod` declares `go 1.26.1` |
+| `protoc` + `protoc-gen-go` + `protoc-gen-go-grpc` | plugins must be on `PATH` — they land in `$(go env GOPATH)/bin` |
+| `tmux` | required for live terminals; without it the orchestrator runs headless |
+| Godot >= 4.3 | `setup.sh` pins 4.4.1 when installing from GitHub releases |
+| Docker + compose | only for the Redis container used by `make test-integration` |
+
+```bash
+./setup.sh   # system packages, protoc plugins, godot-xterm addon, generate + build, redis
+./run.sh     # orchestrator + Godot
+```
+
+`setup.sh` supports Arch, Debian/Ubuntu and macOS. `run.sh` rebuilds `bin/orchestrator`
+itself when any Go source is newer than the binary, polls the bridge address for up to 10s
+before launching Godot, and traps INT/TERM to kill Godot and SIGTERM the orchestrator.
+
+## Ports and environment
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `GRPC_ADDR` | `:50051` | gRPC control plane (agents dial this) |
+| `HEALTH_ADDR` | `:8080` | health HTTP server |
+| `BRIDGE_ADDR` | `127.0.0.1:8081` | HTTP + SSE bridge (the Godot client talks to this) |
+| `BRIDGE_API_KEY` | unset | when set, the bridge requires a bearer token; when unset it logs `no BRIDGE_API_KEY set — running without auth` and serves unauthenticated |
+| `MIN_AGENT_COUNT` | `1` | minimum agent count used by the health aggregator |
+
+## Architecture at a glance
+
+Full reference: [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md).
+
+`cmd/orchestrator` runs two servers in one process:
+
+- **HTTP + SSE bridge (`internal/httpbridge`) on `127.0.0.1:8081`** — this is the
+  Godot-facing transport, not gRPC. Routes: `GET /api/agents`,
+  `GET /api/agents/{id}/output`, `GET /api/floors`, `GET /api/providers`, `POST /api/tasks`,
+  `POST /api/dags`, `POST /api/agents/{id}/input|cancel|reassign|despawn`,
+  `POST /api/agents/spawn`, `POST /api/admin/restart`, `GET /events/stream`.
+- **gRPC (`internal/ipc`, `proto/orchestrator.proto`) on `:50051`** — the
+  agent-to-orchestrator control plane only, dialled by `internal/cliagent` and
+  `internal/simagent`.
+
+Behind those: a supervisor doing registration, heartbeat staleness detection and crash
+recovery with exponential backoff (1s base, 30s cap) plus a sliding-window circuit breaker;
+a DAG engine with cycle detection, Kahn topological levels and level-by-level fail-fast
+execution; and a terminal substrate.
+
+Two things worth knowing before you read the code:
+
+- **State is in-memory.** `cmd/orchestrator/main.go` constructs `state.NewMockStore()`. A
+  complete `RedisStore` exists in `internal/state/redis.go` but has no non-test call sites,
+  so the running binary never connects to Redis. Redis is still started by `setup.sh` /
+  `docker-compose.yml` and required by `make test-integration`.
+- **tmux is the only terminal substrate.** `internal/terminal.Substrate` has exactly one
+  implementation, `TmuxSubstrate`. There is no WezTerm implementation in this repo.
+
+`internal/gateway` contains a complete, tested LiteLLM client and Haiku-based judge-router,
+but it is imported by no `cmd/` binary — the running orchestrator makes no LLM completion
+calls and does no cost-based model routing. Treat it as built-but-unwired.
+
+## Repo layout
+
+| Path | Contents |
+|---|---|
+| `cmd/orchestrator` | supervisor entrypoint — gRPC, health and bridge servers |
+| `cmd/demoworker` | standalone demo worker binary |
+| `cmd/spritegen`, `cmd/assetslice` | asset dev tools |
+| `internal/agent` | agent state machine |
+| `internal/cliagent` | spawns real coding CLIs in tmux, types prompts, polls output |
+| `internal/simagent` | in-process fake worker (`sim` kind) |
+| `internal/supervisor` | registration, heartbeats, restart policy, reapers, assign loop |
+| `internal/dag` | graph, cycle detection, topological sort, executor, status tracker |
+| `internal/httpbridge` | HTTP + SSE bridge for the Godot client |
+| `internal/ipc` | gRPC server, handlers, health HTTP server |
+| `internal/state` | store interface, in-memory `MockStore`, unwired `RedisStore` |
+| `internal/terminal` | `Substrate` interface and the tmux implementation |
+| `internal/health` | health aggregator |
+| `internal/gateway` (+ `providers/`) | LiteLLM client and judge-router (not wired into any binary) |
+| `proto/` | `orchestrator.proto` |
+| `gen/` | generated protobuf/gRPC Go code (gitignored — run `make generate`) |
+| `e2e/` | end-to-end tests, `testenv` build tag |
+| `godot/` | Godot 4 project — scripts, scenes, assets, `tests/`, `addons/` |
+| `specs/` | feature specs |
+| `docs/research/` | pre-build research notes |
+| `config/models.yaml` | model tier definitions used by the gateway package |
+
+## Build and test
+
+```bash
+make generate         # protoc -> gen/pb/orchestrator (needs protoc plugins on PATH)
+make build            # bin/orchestrator
+make test             # go test -race -count=1 ./internal/...
+make test-integration # adds -tags=integration; needs Redis (REDIS_URL)
+make lint             # golangci-lint run ./...
+make clean
+```
+
+A third test tier is gated behind the `testenv` build tag (`internal/dag`,
+`internal/supervisor`, and everything in `e2e/`). **No committed automation runs it** — there
+is no Makefile target and no CI step. To run it by hand:
+
+```bash
+go test -tags=testenv ./internal/... ./e2e/...
+```
+
+Godot tests are standalone headless GDScript files; no GUT or other test runner is vendored:
+
+```bash
+godot --headless --path godot --script tests/<name>.gd
+```
+
+CI (`.github/workflows/ci.yml`) runs on pushes to `main`, `epic/**`, `feature/**` and PRs to
+`main`, `epic/**`: `make generate`, `go vet ./...`, `make test`, then `make test-integration`
+against a `redis:7-alpine` service.
 
 ## Versioning
 
-Format: `YY.MM.Major.Minor`
+Format: `YY.Major.Minor.Patch[Suffix]` — e.g. `26.4.0.0` or `26.4.0.1a`.
 
-| Event | Effect |
-|-------|--------|
-| `task/*` or `feature/*` merged → main | Major +1, Minor → 0 |
-| `bug/*` or `hotfix/*` merged → main | Minor +1 |
-| Monthly rollover | Run **Manual Monthly Version Bump** via Actions |
+| Merged branch | Effect |
+|---|---|
+| `epic/*` | Major +1, Minor and Patch → 0 |
+| `feature/*` | Minor +1, Patch → 0 |
+| `task/*` or `bug/*` | Patch +1 |
+| `hotfix/*` | append/increment suffix letter (a, b … z, aa …) |
 
-Current version: `26.03.1.0`
+Bumps fire only on merged PRs into `main` or `epic/**`. Year rollover is automatic: if the
+`YY` component no longer matches the current year, the version resets to `YY.0.0.0`.
 
-## Development
+Current version: `26.4.0.0`.
+
+## Contributing
 
 All work goes through issues. **Never push directly to `main`.**
 
-1. Create an issue using a template — a branch and draft PR are auto-created
-2. Work on the branch
-3. PR is squash-merged into main (or parent branch for sub-issues)
+1. Create an issue and label it — `issue-branch-handler.yml` auto-creates the branch and a
+   draft PR. Label priority: `epic` > `feature` > `task` > `bug` > `hotfix`.
+2. Branch names are generated as `<type>/<issue#>-kebab-title`; PR titles get the matching
+   conventional-commit prefix (`epic:`, `feat:`, `chore:`, `fix:`, `hotfix:`).
+3. PRs are squash-merged into their parent branch.
 
-See [`.github/CI-CD-Guide.md`](.github/CI-CD-Guide.md) for full workflow details.
-
-## Feature Specs
-
-| Spec | Component |
-|------|-----------|
-| [`go-orchestrator-core-spec.md`](go-orchestrator-core-spec.md) | Supervisor, agent state machine, DAG engine |
-| [`terminal-substrate-spec.md`](terminal-substrate-spec.md) | tmux session management, command injection |
-| [`model-gateway-spec.md`](model-gateway-spec.md) | LiteLLM proxy, Judge-Router, cost tracking |
-| [`pixel-office-ui-spec.md`](pixel-office-ui-spec.md) | Godot 4 pixel-art office, godot-xterm |
+See [`.github/CI-CD-Guide.md`](.github/CI-CD-Guide.md) for the workflow details — note its
+versioning section is stale; the table above matches `version-bump.yml`.
 
 ## godot-xterm (optional native PTY)
 
@@ -76,6 +203,33 @@ godot/addons/install_godot_xterm.sh
 ```
 
 See [`godot/addons/VENDOR.md`](godot/addons/VENDOR.md) for the pinned
-version, verification steps, and platform notes. Without it installed (or
-on Windows), the raw terminal panel falls back to a read-only ANSI view —
-the project runs cleanly either way.
+version, verification steps, and platform notes.
+
+Platform support:
+
+- **Linux/macOS with the addon installed** — live PTY terminal panels backed by tmux.
+- **Without the addon** — the raw terminal panel falls back to a polling, read-only ANSI
+  view. The project runs cleanly either way.
+- **Windows, or any machine without tmux** — the orchestrator logs
+  `terminal substrate unavailable, running headless`. Agents then fall back to one-shot CLI
+  exec (`claude -p …`, `codex exec …`, `opencode run …`, `pi -p …`), and
+  `GET /api/agents/{id}/output` and `POST /api/agents/{id}/input` return `501`.
+
+Other Godot-side notes: [`godot/PORTING.md`](godot/PORTING.md),
+[`godot/PARITY.md`](godot/PARITY.md).
+
+## Specs and research
+
+| Spec | Component |
+|---|---|
+| [`specs/go-orchestrator-core-spec.md`](specs/go-orchestrator-core-spec.md) | Supervisor, agent state machine, DAG engine |
+| [`specs/terminal-substrate-spec.md`](specs/terminal-substrate-spec.md) | tmux session management, command injection |
+| [`specs/model-gateway-spec.md`](specs/model-gateway-spec.md) | LiteLLM proxy, judge-router, cost tracking (built, not wired) |
+| [`specs/pixel-office-ui-spec.md`](specs/pixel-office-ui-spec.md) | Godot 4 pixel office, godot-xterm |
+
+[`specs/`](specs/) holds the full set; [`docs/specs/todo/`](docs/specs/todo/) holds specs not
+yet started. Specs describe intended behaviour — check the code before assuming a spec
+section is implemented.
+
+Pre-build research, including the architectural decision table and competitive landscape,
+lives in [`docs/research/Agentic-Orchestrator-MOC.md`](docs/research/Agentic-Orchestrator-MOC.md).

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,614 @@
+# OrKi Architecture
+
+How the system is actually assembled as of `VERSION` **26.4.0.0** (`VERSION:1`).
+
+This document describes what is built and running. Every load-bearing claim carries a
+`file:line` citation. Things that exist only in a spec, or exist as code but are not wired
+into any binary, are confined to [Planned vs built](#12-planned-vs-built) — they are not
+described anywhere else as if they work.
+
+Repo shape at a glance: 120 `.go` files, 53 of them `*_test.go`; 82 `.gd` files; 29 files
+under `godot/tests/`. Go module is `github.com/Kiriketsuki/agenKic-orKistrator`, language
+version `go 1.26.1` (`go.mod:1-3`).
+
+---
+
+## 1. Purpose and scope
+
+OrKi is a two-process desktop application. A Go orchestrator supervises agents; a Godot 4
+client renders them as pixel characters on the floors of a fisheye-projected tower
+(`godot/scripts/tower/tower_manager.gd:1-2`).
+
+The user summons an agent from the client. Floor 0 is reserved and never accepts a spawn
+(`internal/httpbridge/handlers.go:775-780`). Exactly five spawn kinds are accepted:
+`sim`, `claude`, `codex`, `opencode`, `pi` (`internal/httpbridge/handlers.go:719-729`).
+`sim` is an in-process fake worker (`internal/simagent/simagent.go:1-4`); the other four
+exec a real CLI binary (`internal/cliagent/cliagent.go:71-77`) inside a tmux session named
+`agent-<id>`, type the task prompt into that pane, and poll `CaptureOutput` until two
+identical snapshots indicate the CLI has settled (`internal/cliagent/cliagent.go:242-278`,
+`330-356`).
+
+The bridge also serves that same five-kind roster to the client's summon grid
+(`internal/httpbridge/handlers.go:684-690`).
+
+UI surfaces on the Godot side: the Grimoire spawn flyout (F3), the Panels flyout (F5), the
+Power flyout (F4), a quest board (single task plus small DAG submission), a spell scroll
+(parchment output view), a raw terminal view, a minimap, a hex compass, floor tabs, and a
+right-click agent context menu.
+
+---
+
+## 2. Process topology
+
+Three kinds of process exist at runtime:
+
+1. **`bin/orchestrator`** — the Go supervisor. One process, three listeners.
+2. **The Godot client** — one process, launched with `godot --path godot`.
+3. **One tmux session per CLI agent**, named `agent-<agentID>`
+   (`internal/cliagent/cliagent.go:156`), each running a real CLI (`claude`, `codex`,
+   `opencode`, `pi`) via `cd <workdir> && clear && exec <bin>`
+   (`internal/cliagent/cliagent.go:201`).
+
+```
+                      ./run.sh
+                         |
+        +----------------+-----------------+
+        |                                  |
+  bin/orchestrator                    godot --path godot
+        |                                  |
+        |  :50051  gRPC   <----------------+---- NOT used by Godot
+        |  :8080   health HTTP (/healthz /readyz /progress)
+        |  127.0.0.1:8081  HTTP + SSE bridge  <--- Godot talks here
+        |
+        |  supervisor + tmux substrate
+        v
+   tmux sessions:  agent-<id>   agent-<id>   agent-<id>  ...
+                      |             |            |
+                    claude        codex       opencode
+                      \             |            /
+                       \            |           /
+                        gRPC dial back to :50051
+                        (cliagent / simagent only)
+```
+
+Ports and their env overrides:
+
+| Listener | Default | Env var | Cite |
+|---|---|---|---|
+| gRPC | `:50051` | `GRPC_ADDR` | `cmd/orchestrator/main.go:30-33` |
+| Health HTTP | `:8080` | `HEALTH_ADDR` | `cmd/orchestrator/main.go:35-38` |
+| HTTP/SSE bridge | `127.0.0.1:8081` | `BRIDGE_ADDR` | `cmd/orchestrator/main.go:84-87` |
+
+The startup banner prints all three (`cmd/orchestrator/main.go:196`).
+
+### The launcher
+
+`./run.sh` is the supported way to start both processes.
+
+- Rebuild only when stale: any `.go` file under `cmd/` or `internal/`, or `go.mod`, newer
+  than `bin/orchestrator` triggers `make generate build` with `$HOME/go/bin` prepended to
+  `PATH` for the protoc plugins (`run.sh:29-41`).
+- Start the orchestrator in the background (`run.sh:62-64`).
+- Poll `BRIDGE_HOST` (default `127.0.0.1:8081`) via `/dev/tcp`, 50 attempts at 0.2s — up
+  to 10 seconds — and abort if the orchestrator exits during startup (`run.sh:66-81`).
+- Launch `godot --path godot` (`run.sh:85-87`).
+- `wait -n` on both PIDs, so either process dying ends the script (`run.sh:91`).
+- A single `cleanup` trap on `INT TERM EXIT` kills Godot, then `kill -TERM`s the
+  orchestrator so its graceful-shutdown path runs (`run.sh:44-58`).
+
+Graceful shutdown inside the orchestrator cancels the root context, stops the gRPC server,
+drains the health and bridge HTTP servers with a 5s timeout, shuts the DAG executor down,
+and stops the supervisor — in that order (`cmd/orchestrator/main.go:224-234`). The same
+function serves both the signal handler (`cmd/orchestrator/main.go:189-193`) and
+`POST /api/admin/restart`.
+
+---
+
+## 3. Orchestrator-to-client protocol: the HTTP/SSE bridge
+
+The Godot client speaks HTTP and Server-Sent Events to `internal/httpbridge`. It does not
+speak gRPC.
+
+### Endpoints
+
+All routes are registered in one place (`internal/httpbridge/bridge.go:178-192`):
+
+| Method | Path | Purpose |
+|---|---|---|
+| GET | `/api/agents` | List agents and their states |
+| GET | `/api/agents/{id}/output` | Visible-pane snapshot from the agent's tmux session |
+| GET | `/api/floors` | Tower floors, derived from tmux sessions |
+| GET | `/api/providers` | Spawn-kind roster for the summon grid |
+| POST | `/api/tasks` | Enqueue a task |
+| POST | `/api/dags` | Submit a DAG for execution |
+| POST | `/api/agents/{id}/input` | Send keystrokes/text into the agent's pane |
+| POST | `/api/agents/{id}/cancel` | Interrupt and detach the agent's current task |
+| POST | `/api/agents/{id}/reassign` | Requeue the current task with a tier/provider hint |
+| POST | `/api/agents/{id}/despawn` | Remove the agent and destroy its tmux session |
+| POST | `/api/agents/spawn` | Summon a new agent |
+| POST | `/api/admin/restart` | Re-exec the orchestrator binary |
+| GET | `/events/stream` | SSE event stream |
+
+### SSE events
+
+`/events/stream` emits dot-namespaced event types. The client dispatches on them in
+`godot/scripts/autoload/bridge_manager.gd:297-354`; the orchestrator emits them in
+`internal/httpbridge/sse.go:194-310`:
+
+| Wire event type | Emitted at | Godot signal |
+|---|---|---|
+| `agent.registered` | `sse.go:194` | `agent_registered` (`bridge_manager.gd:299`) |
+| `agent.state_changed` | `sse.go:205,215,224,233,242,276` | `agent_state_changed` (`bridge_manager.gd:306`) |
+| `agent.deregistered` | `sse.go:256` | `agent_deregistered` (`bridge_manager.gd:334`) |
+| `agent.output` | `sse.go:285` | `agent_output` (`bridge_manager.gd:341`) |
+| `floor.created` | `sse.go:300` | `floor_created` (`bridge_manager.gd:344`) |
+| `floor.removed` | `sse.go:310` | `floor_removed` (`bridge_manager.gd:348`) |
+
+The client reconnects with `?since=<cursor>` from the last event carrying a `cursor` field
+(`bridge_manager.gd:245-251,353-354`) and treats 20s of silence as a dead connection
+(`bridge_manager.gd:358-360`).
+
+### Auth
+
+Bearer-token auth is enabled **only** when `BRIDGE_API_KEY` is set. Otherwise the
+orchestrator logs `HTTP bridge: no BRIDGE_API_KEY set — running without auth` and serves
+every route unauthenticated (`cmd/orchestrator/main.go:131-136`). The middleware is only
+installed when a key is present (`internal/httpbridge/bridge.go:195-197`) and compares in
+constant time (`internal/httpbridge/bridge.go:425-438`).
+
+### Semantics worth knowing before you change a handler
+
+- **Task priority is a min-heap.** Lower score dequeues first
+  (`internal/state/store.go:139-141`).
+- **Cancel bypasses the state machine.** It sends `\x03` (Ctrl-C) into `agent-<id>`
+  best-effort, clears the current task, then settles the agent to idle via a CAS with a
+  tolerant re-read — not through `agent.Machine` (`internal/httpbridge/handlers.go:363-379`,
+  `651`). It also calls `CompletionRegistry.Complete(taskID)` so a DAG node blocked on that
+  task unblocks (`internal/httpbridge/handlers.go:390-395`).
+- **Reassign is a hint, not a migration.** It re-enqueues the task at its original priority
+  with `Tier`/`Provider` written into `TaskMeta`, but nothing in the supervisor's assign
+  loop reads those fields, so the very same agent frequently picks the task back up. The
+  handler's own doc comment says so explicitly (`internal/httpbridge/handlers.go:403-421`,
+  `484-508`).
+- **Despawn destroys the tmux session** (`internal/httpbridge/handlers.go:562`).
+- **`/output` and `/input` return 501** when no terminal substrate is wired
+  (`internal/httpbridge/handlers.go:62-69`, `234-241`).
+- **`/floors` filters out `agent-*` sessions**, because a per-agent PTY is not a tower floor
+  (`internal/httpbridge/handlers.go:107-135`). With no substrate it returns an empty list
+  rather than 501.
+- **Spawn reserves the floor slot before calling the spawner** and releases the reservation
+  if the spawner fails, closing a TOCTOU window on floor capacity
+  (`internal/httpbridge/handlers.go:766-800`).
+
+---
+
+## 4. Agent control plane: gRPC
+
+`proto/orchestrator.proto` defines one service, `OrchestratorService`
+(`proto/orchestrator.proto:9`), implemented by `internal/ipc`
+(`internal/ipc/server.go:27-65`):
+
+| RPC | Proto | Handler |
+|---|---|---|
+| `RegisterAgent` | `:11` | `handlers.go:48` |
+| `SubmitTask` | `:14` | `handlers.go:57` |
+| `StreamOutput` (bidi stream) | `:17` | `handlers.go:92` |
+| `GetAgentState` | `:20` | `handlers.go:72` |
+| `SubmitDAG` | `:23` | `handlers.go:150` |
+| `GetDAGStatus` | `:26` | `handlers.go:232` |
+| `CompleteAgent` | `:29` | `handlers.go:207` |
+| `Heartbeat` | `:32` | `handlers.go:218` |
+| `StartWork` | `:35` | `handlers.go:171` |
+| `ReportOutput` | `:38` | `handlers.go:189` |
+
+`StartGRPC` also registers the standard gRPC health service when a health server is
+supplied (`internal/ipc/server.go:60-62`), which `main` wires and drives on a 2s ticker.
+
+**Who dials `:50051`:** only `internal/cliagent` (`cliagent.go:130-134`) and
+`internal/simagent` (`simagent.go:27-32`). Both are in-process spawners that connect back
+to the orchestrator's own endpoint — `main` rewrites a bare `:50051` to `127.0.0.1:50051`
+for the loopback dial (`cmd/orchestrator/main.go:99-102`). The Godot client is not a gRPC
+client.
+
+**Regeneration:** `make generate` runs `protoc` with the Go and Go-gRPC plugins, writing
+into `gen/pb/orchestrator` (`Makefile:8-17`). `gen/` is gitignored, so a fresh checkout
+must generate before it will build; `protoc-gen-go` and `protoc-gen-go-grpc` live in
+`$HOME/go/bin`, which `run.sh` and `setup.sh` prepend to `PATH` explicitly
+(`run.sh:38-40`, `setup.sh:108`).
+
+---
+
+## 5. Agent lifecycle
+
+Spawn, end to end:
+
+1. The Grimoire flyout issues `POST /api/agents/spawn`.
+2. Kind is validated against the five-item allowlist; empty defaults to `sim`
+   (`internal/httpbridge/handlers.go:718-729`). Name and tier are defaulted from
+   round-robin tables when omitted (`handlers.go:730-737`).
+3. `workdir`, if given, must be an existing absolute directory (`handlers.go:739-758`).
+4. A floor slot is reserved atomically; floor 0 is rejected outright
+   (`handlers.go:766-796`).
+5. The `AgentSpawner` closure runs (`cmd/orchestrator/main.go:117-129`): `sim` goes to
+   `simagent.Spawn`, everything else to `cliagent.Spawn` with the substrate and workdir
+   options attached.
+6. `cliagent.Spawn` checks the CLI binary is on `PATH`, dials gRPC, and calls
+   `RegisterAgent` (`internal/cliagent/cliagent.go:117-141`).
+7. The supervisor creates the bare tmux session during registration; `cliagent` then
+   launches the interactive CLI inside it (`internal/cliagent/cliagent.go:156-163`,
+   `173-207`). If that fails it logs and falls back to headless one-shot exec.
+8. The agent's worker loop heartbeats every 3s and polls its own state. On `ASSIGNED` it
+   resolves the prompt from the store, calls `StartWork`, and either types the prompt into
+   the pane (interactive) or runs the one-shot command (headless)
+   (`internal/cliagent/cliagent.go:219-256`).
+9. Settle detection: poll `CaptureOutput(session, 50)` every 5s; return when two
+   consecutive snapshots match **and** at least 15s has elapsed, or at the 5-minute
+   `taskTimeout` cap (`internal/cliagent/cliagent.go:35`, `45-46`, `329-356`).
+10. One output chunk is streamed, then `ReportOutput` + `CompleteAgent`
+    (`internal/cliagent/cliagent.go:283-290`).
+
+### State machine
+
+Four states — `idle`, `assigned`, `working`, `reporting` (`internal/agent/state.go:14-19`) —
+and five events (`internal/agent/event.go:6-12`).
+
+```
+  idle --task_assigned--> assigned --work_started--> working
+    ^                                                   |
+    |                                             output_ready
+    |                                                   v
+    +----------output_delivered----------------- reporting
+
+  agent_failed: from ANY state -> idle
+```
+
+The table is the whole truth; anything not in it is an `InvalidTransitionError`
+(`internal/agent/transition.go:5-37`). `Machine.ApplyEvent` reads the current state,
+validates the transition, and persists via `CompareAndSetAgentState`, returning an
+immutable snapshot — the `Machine` holds no mutable state of its own
+(`internal/agent/machine.go:14-73`). CAS is the atomicity guard for the transition itself;
+the supervisor's per-agent mutex remains necessary for compound operations
+(`internal/agent/machine.go:34-41`).
+
+---
+
+## 6. Supervisor
+
+`internal/supervisor/supervisor.go` (~769 lines) owns agent registration
+(`:108`), a heartbeat loop (`:251`) with staleness checking (`:265`) against a 30s
+threshold (`:18`), crash recovery (`crashAgent`, `:304`), the task-assign loop (`:390`,
+`:404`) with idle-agent selection (`:531`), and the gRPC-facing lifecycle methods
+`Heartbeat` / `StartWork` / `ReportOutput` / `CompleteAgent` (`:580`, `:612`, `:641`,
+`:669`). Per-agent mutexes serialize compound operations (`:765`).
+
+### Restart policy
+
+`internal/supervisor/restart.go` — exponential backoff with a sliding-window circuit
+breaker. Defaults (`restart.go:70-77`):
+
+| Knob | Default |
+|---|---|
+| `baseBackoff` | 1s |
+| `maxBackoff` | 30s |
+| `crashThreshold` | 5 |
+| `crashWindow` | 60s |
+
+More than `crashThreshold` crashes inside `crashWindow` opens the circuit and returns
+`ShouldRestart: false` with `ErrCircuitOpen` (`restart.go:97-113`). Otherwise backoff is
+`min(base * 2^(n-1), max)` over the consecutive-crash counter (`restart.go:136-144`).
+`RecordSuccess` clears both the counter and the crash history (`restart.go:126-132`).
+
+### Two reapers
+
+They are separate and easily confused:
+
+1. **Tombstone sweep** — `CompletionRegistry.SweepOnce` drops expired cancel tombstones and
+   unclaimed pre-closed waiter entries (`completion.go:166-190`), driven by
+   `StartReaper` on a ticker (`completion.go:191-214`). TTL is `2 * staleThreshold` and the
+   sweep interval is `staleThreshold` (`completion.go:9-18`). `main` starts it against the
+   root context (`cmd/orchestrator/main.go:71`).
+2. **Orphan tmux session sweep** — every 15s, drop agents whose terminal session no longer
+   exists (`reaper.go:12-16`, `reapLoop` at `reaper.go:43`). Session-name matching uses the
+   shared `agent-` prefix constant so it cannot drift from the name construction
+   (`reaper.go:18-21`).
+
+### ShutdownHandler is not used
+
+`supervisor.NewShutdownHandler` exists (`internal/supervisor/shutdown.go:11-19`) but has no
+non-test callers — the only references are in `internal/supervisor/shutdown_test.go`.
+`main` does its own signal handling and calls its own `gracefulShutdown`
+(`cmd/orchestrator/main.go:189-193`, `224-234`).
+
+---
+
+## 7. DAG engine
+
+`internal/dag`:
+
+- **Graph construction and validation** — `NewGraph` returns `ErrEmptyDAG`,
+  `ErrDuplicateNode`, `ErrNodeNotFound`, or `ErrCycleDetected` (`graph.go:19-70`), with
+  `Predecessors`, `TaskSpec`, `successorsOf`, and `inDegrees` accessors (`graph.go:74-111`).
+- **Topological levels** — Kahn's algorithm, returning `[][]string` levels and
+  `ErrCycleDetected` on a cycle (`sort.go:8-47`).
+- **Executor** — level-by-level execution with fail-fast: `Execute` (`executor.go:50`),
+  `run` (`executor.go:91`), `executeNode` (`executor.go:121`), plus `ActiveExecutionCount`
+  and `Shutdown` (`executor.go:37-42`).
+- **StatusTracker** — per-execution node status with `MarkNodeRunning` /
+  `MarkNodeCompleted` / `MarkNodeFailed`, an `ActiveCount`, and proto conversion
+  (`status.go:64-205`).
+
+### Two submitters
+
+`StoreSubmitter` is **deprecated** and enqueue-only. Its own doc comment states that a nil
+return reflects enqueue success, not task execution, so the executor's `MarkNodeCompleted`
+would be a lie about dependency ordering (`storesubmitter.go:11-24`).
+
+`BlockingSubmitter` blocks on `CompletionRegistry.Wait` and is the one that is wired:
+
+```go
+submitter := dag.NewBlockingSubmitter(store, registry)
+executor  := dag.NewExecutor(ctx, submitter)
+```
+— `cmd/orchestrator/main.go:73-74`. The same `registry` instance is handed to the
+supervisor and to the HTTP bridge, so a cancel through the bridge unblocks the exact DAG
+node waiting on that task (`cmd/orchestrator/main.go:51`, `88-95`).
+
+---
+
+## 8. State layer
+
+`state.StateStore` is the single storage interface: agent state (with CAS), agent field
+records, an event stream with consumer groups, agent/task binding, and a priority task
+queue, plus `Ping`/`Close` (`internal/state/store.go:95-153`).
+
+**The running orchestrator uses `MockStore`, in memory:**
+
+```go
+store := state.NewMockStore()
+```
+— `cmd/orchestrator/main.go:47`. That is the only store constructed anywhere in `cmd/`.
+
+`RedisStore` is complete (`internal/state/redis.go`, ~503 lines) but `NewRedisStore` has
+**zero non-test call sites** — the only callers are `internal/state/redis_test.go:25,41` and
+`internal/state/redis_taskmeta_test.go:27`. `go-redis` remains a direct dependency
+(`go.mod:7`).
+
+The health aggregator's `HealthSnapshot.RedisPingOK` field is a naming holdover: it is set
+from a `Ping` on whatever store was injected (`internal/health/aggregator.go:19-35`,
+`132`), which in the shipped binary is the `MockStore`.
+
+**Where Redis is genuinely required today:** `make test-integration`, which runs the
+`integration`-tagged tests with a live `REDIS_URL` (`Makefile:22-23`), and CI, which starts
+a `redis:7-alpine` service for exactly that step (`.github/workflows/ci.yml:13-22`,
+`50-53`). `setup.sh` starts the same container via `docker-compose.yml`
+(`setup.sh:110-115`, `docker-compose.yml:3-13`). The orchestrator binary itself never
+connects to it.
+
+---
+
+## 9. Terminal substrate
+
+`terminal.Substrate` is the substrate-agnostic interface
+(`internal/terminal/substrate.go:9-38`):
+
+| Method | Purpose |
+|---|---|
+| `SpawnSession(ctx, name, cmd)` | Create a detached session running `cmd` |
+| `DestroySession(ctx, name)` | Kill the session and all its panes |
+| `SendCommand(ctx, session, cmd)` | Type a command into the active pane, then Enter |
+| `SendKey(ctx, session, key)` | Send one real key press (not typed literally) |
+| `CaptureOutput(ctx, session, lines)` | Read the last N lines from the active pane |
+| `ListSessions(ctx)` | All sessions the substrate manages |
+| `SplitPane(ctx, session, direction)` | Split the active pane |
+
+**`TmuxSubstrate` is the only implementation** (`internal/terminal/tmux.go:10-26`). It
+resolves the binary with `exec.LookPath("tmux")` and returns `ErrTmuxNotFound` if it is
+absent. There is no WezTerm code in the repo — `find . -iname '*wezterm*'` returns nothing.
+
+Session naming is `agent-<agentID>` (`internal/cliagent/cliagent.go:156`), with the
+`agent-` prefix pinned to one constant so the reaper and the floor listing cannot drift
+from it (`internal/supervisor/reaper.go:18-21`). `/api/floors` skips any session matching
+that prefix (`internal/httpbridge/handlers.go:120-125`).
+
+### Headless degradation
+
+If tmux is not on `PATH`, `main` logs `terminal substrate unavailable, running headless`
+and simply never attaches a substrate (`cmd/orchestrator/main.go:55-60`). Consequences:
+
+- `cliagent` falls back to one-shot exec (`internal/cliagent/cliagent.go:53-67`), running:
+  - `claude -p <prompt> --output-format text`
+  - `codex exec --skip-git-repo-check <prompt>`
+  - `opencode run <prompt>`
+  - `pi -p <prompt>`
+  Output is streamed line by line over `StreamOutput`, killed at the 5-minute timeout, then
+  `ReportOutput` + `CompleteAgent` (`internal/cliagent/cliagent.go:358-436`).
+- `/api/agents/{id}/output` and `/api/agents/{id}/input` return 501
+  (`internal/httpbridge/handlers.go:62-69`, `234-241`).
+- `/api/floors` returns an empty list (`internal/httpbridge/handlers.go:108-111`).
+
+---
+
+## 10. Godot client
+
+The client is a Godot 4 project rooted at `godot/`. One autoload:
+`godot/scripts/autoload/bridge_manager.gd` — the HTTP client plus the SSE reader. It owns
+connection setup (`:220-231`), the poll/parse loop (`:232-289`), event dispatch
+(`:297-354`), cursor tracking for resumable reconnects (`:353-354`), and a 20s keepalive
+timeout (`:358-360`). It also caches agent and floor state so views can read it
+synchronously.
+
+Script layout under `godot/scripts/`:
+
+| Directory | Responsibility |
+|---|---|
+| `tower/` | `tower_manager.gd` (fisheye layout, floor ordering, scroll/zoom, signal routing), `floor_scene.gd`, `floor_prism.gd`, `floor_morph.gd`, `floor_hit_test.gd`, `edge_layout.gd`, `backdrop_parallax.gd`, `tower_exterior.gd` |
+| `panels/` | `terminal_view.gd`, `spell_scroll_view.gd`, `quest_board_view.gd`, `panel_content_router.gd`, ANSI parsing (`ansi_sepia_parser.gd`, `ansi_sgr_scanner.gd`), `key_passthrough.gd` |
+| `overlays/` | `agent_context_menu.gd`, `status_overlay.gd`, `status_overlay_manager.gd` |
+| `ui/` | flyouts (`grimoire_flyout.gd`, `panels_flyout.gd`, `power_flyout.gd`), `minimap.gd`, `hex_compass.gd`, `edge_compass.gd`, `floor_tabs.gd`, `floor_banner.gd`, orbs, title screen, sigil config |
+| `agents/` | `agent_character.gd`, `agent_sprite.gd`, `floating_rune.gd`, `rune_filter.gd` |
+| `models/` | pure-logic modules: `bridge_data.gd`, `wander_math.gd`, `particle_math.gd`, `panel_float_math.gd`, `palette_math.gd`, `tower_config.gd`, `provider_palette.gd` |
+
+Panel framework lives at the `scripts/` root: `panel_manager.gd` with its extracted
+`panel_manager_math.gd`, `panel_base.gd`, `layout_presets.gd` (persisted F5 arrangements,
+`layout_presets.gd:2-9`), `layout_persistence.gd`, and the `dwindle_tree.gd` /
+`dwindle_node.gd` tiling pair.
+
+### TerminalView has two modes
+
+`godot/scripts/panels/terminal_view.gd:1-22` documents both, and the code implements both:
+
+1. **Live PTY** (Linux/macOS) — godot-xterm's `Terminal` and `PTY` GDExtension classes,
+   instantiated reflectively via `ClassDB` so the script still parses when the addon is
+   absent (`terminal_view.gd:185`, `213-229`). The PTY forks
+   `tmux attach -t agent-<id>` at 80x24 (`terminal_view.gd:236-239`).
+2. **Polled fallback** — a `RichTextLabel` refreshed from
+   `GET /api/agents/{id}/output` every `SCREEN_POLL_SECONDS = 0.7`
+   (`terminal_view.gd:26-27`, `350-374`). This is what runs when the addon is missing or
+   the agent has no live tmux session (`terminal_view.gd:275`).
+
+godot-xterm is **not committed** — `godot/addons/godot_xterm/` is gitignored
+(`.gitignore:50`). Install it with `godot/addons/install_godot_xterm.sh`, which `setup.sh`
+invokes (`setup.sh:100`); provenance is recorded in `godot/addons/VENDOR.md`.
+
+### Cosmetic layers carry no runtime meaning
+
+Several dictionaries name providers that cannot be spawned. `TerminalView.PROVIDER_GLYPHS`
+carries entries for `gemini`, `openai`, `ollama`, and `deepseek`
+(`terminal_view.gd:32-39`), and the context menu's Reassign submenu offers the same list
+(`godot/scripts/overlays/agent_context_menu.gd:27`). These are glyph and colour choices
+only. The spawnable set is the bridge's five kinds
+(`internal/httpbridge/handlers.go:684-690`, `719-729`), and Reassign persists an inert hint
+regardless of which one is picked (§3).
+
+### Pure logic and headless tests
+
+Math and configuration logic is deliberately extracted into plain scripts with no autoload
+or scene dependencies — `models/wander_math.gd`, `models/particle_math.gd`,
+`models/panel_float_math.gd`, `ui/panels_flyout_math.gd`, `ui/power_flyout_math.gd`,
+`ui/title_focus_math.gd`, `panel_manager_math.gd` — so they can be exercised without
+booting the UI.
+
+No GUT or other Godot test runner is vendored (`godot/tests/wander_math_test.gd:5-6`). Each
+test is a standalone `SceneTree` script that exits 1 on failure
+(`godot/tests/wander_math_test.gd:18-21`), run as:
+
+```
+godot --headless --path godot --script tests/wander_math_test.gd
+```
+— `godot/tests/wander_math_test.gd:9`. There are 29 files under `godot/tests/` (`.gd`
+scripts plus their `.uid` companions). Nothing in CI runs them.
+
+---
+
+## 11. Gateway — built, not wired
+
+`internal/gateway` is a complete and well-tested LiteLLM client and judge-router. It is
+imported by **no** binary under `cmd/` (`grep -rn "gateway" cmd/` returns nothing), so the
+running orchestrator makes no LLM completion calls and performs no cost-based routing.
+
+What is there:
+
+- **Interfaces** — `Gateway`, `Router`, `Completer`, `AdapterResolver`, `CostTracker`
+  (`internal/gateway/gateway.go:220-255`), over a three-tier model:
+  `cheap` / `mid` / `frontier` (`gateway.go:12-16`).
+- **JudgeRouter** — asks a cheap judge model to classify a task into one of the three
+  tiers, defaulting to `claude-haiku-4-5-20251001` and falling back to `mid` when
+  classification fails (`internal/gateway/router.go:11`, `23-77`).
+- **LiteLLMClient** — POSTs OpenAI-compatible requests to `<baseURL>/chat/completions`,
+  default base URL `http://localhost:8000` (`internal/gateway/litellm.go:18`, `107-140`).
+- **Provider adapters** — a `FormatAdapter` interface and `Registry`
+  (`internal/gateway/providers/provider.go:9-31`) with `anthropic.go`, `openai.go`, and
+  `ollama.go`.
+- **Supporting code** — `config.go`, `cost.go`, `fallback.go`, each with a test file.
+- **`config/models.yaml`** — tier definitions, primary models, and fallback chains. Note it
+  names `litellm_base_url: "http://localhost:4000"` (`config/models.yaml:2`), which does not
+  match the client's compiled-in default of port 8000; nothing loads the file at runtime
+  today, so the two have never had to agree.
+
+---
+
+## 12. Planned vs built
+
+| Item | What the research/spec said | What exists | What is missing |
+|---|---|---|---|
+| Redis-backed state | Redis Streams + Hashes as the durable state layer | `internal/state/redis.go` (~503 lines), fully tested against a live Redis | `NewRedisStore` has no non-test caller; `main.go:47` constructs `MockStore`. Redis is only needed for `make test-integration` and CI |
+| LiteLLM gateway + judge-router | Haiku judges, Sonnet works, Opus architects; cost tracking and fallback chains | `internal/gateway` complete with tests, plus `config/models.yaml` | No `cmd/` binary imports it; no runtime completion calls, no routing, no cost tracking |
+| WezTerm substrate | A second `Substrate` implementation alongside tmux | Nothing. `TmuxSubstrate` is the only implementation (`internal/terminal/tmux.go:10-11`) | All of it. `find -iname '*wezterm*'` is empty |
+| gRPC as the UI transport | Godot talks to the orchestrator over gRPC | gRPC exists on `:50051` but serves only agents (`cliagent`, `simagent`) | The UI transport is the HTTP/SSE bridge on `127.0.0.1:8081` (`internal/httpbridge/bridge.go:178-192`) |
+| Bubbletea / Lip Gloss TUI | An alternative Go TUI front end | No such code found in the repo | All of it |
+| Gemini / OpenAI / Ollama / DeepSeek agents | Multi-provider agent roster | Glyph and colour dictionaries only (`terminal_view.gd:32-39`, `agent_context_menu.gd:27`) | They are not spawnable — spawn accepts exactly `sim`, `claude`, `codex`, `opencode`, `pi` (`internal/httpbridge/handlers.go:719-729`) |
+| Reassign as live migration | Move a running agent to another provider/tier | Requeue with `Tier`/`Provider` written into `TaskMeta` (`handlers.go:484-508`) | The assign loop never reads those fields; the same agent often re-takes the task (`handlers.go:403-421`) |
+| `testenv` suite and Godot tests in CI | Full lifecycle coverage in the pipeline | `testenv`-tagged tests in `internal/dag/executor_test.go`, `internal/supervisor/*`, and all of `e2e/`; 29 files under `godot/tests/` | Neither runs in CI and neither has a Makefile target. Manual invocation is `go test -tags=testenv ./internal/... ./e2e/...` (inferred from the build tags — not documented anywhere in the repo) and `godot --headless --path godot --script tests/<name>.gd` |
+
+---
+
+## Build, run, test
+
+```
+make generate         # protoc -> gen/pb/orchestrator (gitignored)
+make build            # bin/orchestrator from ./cmd/orchestrator
+make test             # go test -race -count=1 ./internal/...
+make test-integration # adds -tags=integration; needs REDIS_URL
+make lint             # golangci-lint run ./...
+make clean            # rm -rf bin/ gen/pb/
+```
+— `Makefile:1-31`. `make generate` needs `protoc-gen-go` and `protoc-gen-go-grpc` on `PATH`;
+both live in `$HOME/go/bin`.
+
+`cmd/` holds four binaries: `orchestrator` (the supervisor), `demoworker`, and two asset dev
+tools, `spritegen` and `assetslice`.
+
+CI (`.github/workflows/ci.yml`) runs on push to `main`, `epic/**`, `feature/**` and on PRs
+to `main`, `epic/**` (`:3-7`). Steps: install protoc 27.x and the Go plugins,
+`make generate`, `go vet ./...`, `make test`, then `make test-integration` with
+`REDIS_URL=redis://localhost:6379` against a `redis:7-alpine` service (`:31-53`). The Go
+version comes from `go.mod` (`:27-29`).
+
+### Versioning
+
+`YY.Major.Minor.Patch[Suffix]`, validated against
+`^([0-9]{2})\.([0-9]+)\.([0-9]+)\.([0-9]+)([a-zA-Z]*)$`
+(`.github/workflows/version-bump.yml:69-80`, `.github/workflows/version-validation.yml:31-36`).
+Bumps fire only on merged PRs into `main` or `epic/**`:
+
+| Branch prefix | Effect |
+|---|---|
+| `epic/*` | Major +1, Minor and Patch reset to 0 |
+| `feature/*` | Minor +1, Patch reset to 0 |
+| `task/*`, `bug/*` | Patch +1 |
+| `hotfix/*` | Append/increment a suffix letter (a…z, aa…) |
+
+— `version-bump.yml:88-131`. Year rollover is automatic: a `YY` that no longer matches
+`date +%y` resets the version to `<YY>.0.0.0` (`version-bump.yml:82-87`).
+
+`issue-branch-handler.yml` auto-creates a branch and a draft PR when an issue is labelled.
+Label priority is `epic` > `feature` > `task` > `bug` > `hotfix`, and PR titles get the
+prefixes `epic:` / `feat:` / `chore:` / `fix:` / `hotfix:`.
+
+> The version scheme described in `README.md` and `.github/CI-CD-Guide.md` (`YY.MM.Major.Minor`)
+> is stale. The workflow regex above is authoritative.
+
+---
+
+## 13. Pointers
+
+Feature specs live in **`specs/`**, not at the repo root:
+
+- [`specs/go-orchestrator-core-spec.md`](../specs/go-orchestrator-core-spec.md)
+- [`specs/terminal-substrate-spec.md`](../specs/terminal-substrate-spec.md)
+- [`specs/model-gateway-spec.md`](../specs/model-gateway-spec.md)
+- [`specs/pixel-office-ui-spec.md`](../specs/pixel-office-ui-spec.md)
+
+`specs/` holds 16 spec files in total; `docs/specs/todo/` holds 6 more that are not yet
+built.
+
+Other useful documents:
+
+- [`docs/research/Agentic-Orchestrator-MOC.md`](research/Agentic-Orchestrator-MOC.md) —
+  the pre-build research map. Read it as **historical intent**, not as a description of the
+  current system; several of its decisions were superseded (see §12).
+- [`godot/PORTING.md`](../godot/PORTING.md)
+- [`godot/PARITY.md`](../godot/PARITY.md)
+- [`godot/addons/VENDOR.md`](../godot/addons/VENDOR.md) — godot-xterm provenance and install
+- [`.github/CI-CD-Guide.md`](../.github/CI-CD-Guide.md) — CI/CD walkthrough; its version
+  section is stale (see above)


### PR DESCRIPTION
## Summary

README.md, CLAUDE.md and AGENTS.md all still described this repo as being in the
"research and spike phase" with no application code, while the tree holds ~120 Go
files and ~82 GDScript files behind a working two-process app. This rewrites all
three against the actual source and adds `docs/ARCHITECTURE.md` as the deep reference.

## Corrections

| Was documented | Reality |
|---|---|
| gRPC is the Godot-facing transport | HTTP+SSE bridge on `127.0.0.1:8081`, 13 routes (`internal/httpbridge/bridge.go:178-192`). gRPC on `:50051` is the agent control plane only. |
| Redis Streams/Hashes are the state layer | `state.NewMockStore()` (`cmd/orchestrator/main.go:47`). `NewRedisStore` has no non-test call site; Redis is only needed for `make test-integration`. |
| LiteLLM gateway + judge-router is the model layer | `internal/gateway` is built but not imported by `cmd/` — now labelled "built, not wired". |
| Version format `YY.MM.Major.Minor` (README) | `YY.Major.Minor.Patch[Suffix]` per `version-bump.yml:33-47`. README corrected to match CLAUDE.md. |
| `tests: none yet` badge, `go 1.23+` | 53 `_test.go` files + 29 Godot test files; `go 1.26.1` per go.mod. |
| Bubbletea / WezTerm in the stack table | Neither exists in the tree. Rows removed. |
| Four spec links at repo root | Those files live under `specs/`. Links fixed. |
| Multi-provider routing | Only `claude` spawns a real CLI; the rest of the roster is cosmetic. Now stated plainly. |

## New

`docs/ARCHITECTURE.md` — process topology, full bridge endpoint list, supervisor
model, DAG engine, terminal substrate, Godot client structure and the
pure-logic-plus-headless-test idiom, plus a planned-vs-built table.

## Verification

Four independent fact-checking passes ran against source and returned zero issues.
Independently re-confirmed: restart backoff 1s base / 30s cap / threshold 5
(`internal/supervisor/restart.go:72-74`), `state.NewMockStore()` at `main.go:47`,
`internal/gateway` absent from `cmd/` imports, all relative links in all four docs
resolve, and the generated GitNexus blocks in CLAUDE.md and AGENTS.md are
byte-identical to `main`.

Docs-only — no code touched. `chore/*` maps to `bump_type=none`, so the version
stays at 26.4.0.0.

## Test plan

- [x] All relative links in the four docs resolve
- [x] GitNexus blocks byte-identical to `main`
- [ ] CI green